### PR TITLE
docs: enable full mode for homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 title: Ant Design Mini
 sidemenu: false
+gapless: true
 ---
 
 <code src="./components/home.tsx" inline="true"></code>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 ---
 title: Ant Design Mini
-sidemenu: false
 gapless: true
 ---
 


### PR DESCRIPTION
首页使用全宽模式，去掉页面左右内边距及底部链接（红框范围）：

<img width="1535" alt="图片" src="https://user-images.githubusercontent.com/5035925/154921911-0c81739e-32db-4171-ad3c-0bfbff0cf732.png">