### PR TITLE
Feat/tabs

### DIFF
--- a/demo/app.json
+++ b/demo/app.json
@@ -18,6 +18,7 @@
     "pages/Modal/index",
     "pages/SwipeAction/index",
     "pages/Tabs/index",
+    "pages/TabsFallback/index",
     "pages/VTabs/index",
     "pages/Stepper/index",
     "pages/Steps/index",

--- a/demo/pages/TabsFallback/index.axml
+++ b/demo/pages/TabsFallback/index.axml
@@ -1,0 +1,20 @@
+<tabs 
+  index="{{curIdx}}" 
+  type="{{type}}" 
+  fallback="{{true}}" 
+  sticky="{{sticky}}"
+  onChange="changeTab">
+  <block a:for="{{tabs}}">
+    <tab-content 
+      style="{{curIdx===index ? '' : 'display:none'}}"
+      tab="{{item}}">
+      <view>
+        {{item.title}}
+          <view 
+            a:for="{{height}}">
+            ........根据内容自适应高度........
+          </view>
+      </view>
+    </tab-content>
+  </block>
+</tabs>

--- a/demo/pages/TabsFallback/index.js
+++ b/demo/pages/TabsFallback/index.js
@@ -1,0 +1,81 @@
+const component2 = my.canIUse('component2');
+
+Page({
+  data: {
+    curIdx: 2,
+    height: 30,
+    type: 'basis',
+    animation: false,
+    swipeable: false,
+    titleSlot: false,
+    plusSlot: true,
+    sticky: false,
+    tabs: [
+      {
+        title: '选项一',
+        subTitle: '描述文案',
+        corner: true,
+      },
+      {
+        title: '选项二',
+        subTitle: '描述文案描述',
+      },
+      {
+        title: '选项三',
+        subTitle: '描述',
+      },
+    ],
+    tabsType: [
+      { name: 'basis', value: '普通', checked: true },
+      { name: 'capsule', value: '胶囊' },
+      { name: 'mixin', value: '带描述' },
+    ],
+    tabsNumber: [
+      { name: '1', value: '一条' },
+      { name: '2', value: '两条' },
+      { name: '3', value: '三条' },
+      { name: '-1', value: '很多', checked: true },
+    ],
+    tabsAnimation: [
+      { name: true, value: 'true' },
+      { name: false, value: 'false', checked: true },
+    ],
+    tabsSwipeable: [
+      { name: true, value: 'true' },
+      { name: false, value: 'false', checked: true },
+    ],
+    tabsTitleSlotScope: [
+      { name: true, value: 'true' },
+      { name: false, value: 'false', checked: true },
+    ],
+    tabsSticky: [
+      { name: true, value: 'true' },
+      { name: false, value: 'false', checked: true },
+    ],
+    tabsPlusSlotScope: [
+      { name: true, value: 'true', checked: true },
+      { name: false, value: 'false' },
+    ],
+    canSwipe: true,
+  },
+  onLoad() {
+    if (!component2) {
+      this.setData({
+        canSwipe: component2,
+      });
+    }
+  },
+  // tabs 的点击回调
+  changeTab(e) {
+    this.setData({
+      curIdx: e,
+    });
+  },
+  // 右上角的 plus 区域点击事件
+  iconClick() {
+    my.alert({
+      title: 'slot="plus"',
+      content: '自定义 slot 的 icon 被点击',
+    });
+  },
+});

--- a/demo/pages/TabsFallback/index.json
+++ b/demo/pages/TabsFallback/index.json
@@ -1,0 +1,9 @@
+{
+    "defaultTitle": "Tabs",
+    "usingComponents": {
+      "tabs": "../../../src/Tabs/index",
+      "tab-content": "../../../src/Tabs/TabItem/index",
+      "icon": "../../../src/Icon/index"
+    }
+  }
+  

--- a/demo/pages/TabsSticky/index.axml
+++ b/demo/pages/TabsSticky/index.axml
@@ -1,0 +1,31 @@
+
+<view style="height:200px; z-index:999;background-color:red">
+dd
+</view>
+<tabs 
+  index="{{index}}" 
+  type="basic" 
+  swipeable="{{true}}" 
+  sticky="{{true}}"
+  stickyTop="50px"
+  onChange="changeTab">
+  <block a:for="{{tabs}}">
+    <tab-content 
+      tab="{{item}}">
+      <view>
+      {{index}}
+          <view 
+            a:for="{{200}}">
+            ........根据内容自适应高度........
+          </view>
+      </view>
+    </tab-content>
+  </block>
+</tabs>
+
+
+<text 
+  a:if="{{!canSwipe}}" 
+  class="tips">
+  当前未开启 component2 编译，无法使用 swipeable 属性。
+</text>

--- a/demo/pages/TabsSticky/index.js
+++ b/demo/pages/TabsSticky/index.js
@@ -1,0 +1,201 @@
+const component2 = my.canIUse('component2');
+
+Page({
+  data: {
+    index: 0,
+    type: 'basis',
+    animation: false,
+    swipeable: false,
+    titleSlot: false,
+    plusSlot: true,
+    sticky: false,
+    tabs: [
+      {
+        title: '选项一',
+        subTitle: '描述文案',
+        corner: true,
+      },
+      {
+        title: '选项二',
+        subTitle: '描述文案描述',
+      }
+    ],
+    canSwipe: true,
+  },
+  onLoad() {
+    if (!component2) {
+      this.setData({
+        canSwipe: component2,
+      });
+    }
+  },
+  // 【配置】tabs 选项卡条数修改
+  tabsNumberChange(e) {
+    if (e.detail.value === '1') {
+      this.setData({
+        tabs: [
+          {
+            title: '选项',
+            subTitle: '描述文案',
+            badge: 6,
+          },
+        ],
+      });
+    } else if (e.detail.value === '2') {
+      this.setData({
+        tabs: [
+          {
+            title: '选项',
+            subTitle: '描述文案',
+          },
+          {
+            title: '选项二',
+            subTitle: '描述文案描述',
+          },
+        ],
+      });
+    } else if (e.detail.value === '3') {
+      this.setData({
+        tabs: [
+          {
+            title: '选项一',
+            subTitle: '描述文案',
+          },
+          {
+            title: '选项二',
+            subTitle: '描述文案描述',
+          },
+          {
+            title: '选项三',
+            subTitle: '描述',
+          },
+        ],
+      });
+    } else {
+      this.setData({
+        tabs: [
+          {
+            title: '选项一',
+            subTitle: '描述文案',
+          },
+          {
+            title: '选项二',
+            subTitle: '描述文案描述',
+          },
+          {
+            title: '选项三',
+            subTitle: '描述',
+          },
+          {
+            title: '4 Tab',
+            subTitle: '描述',
+            showBadge: true,
+            badge: 0,
+          },
+          {
+            title: '5 Tab',
+            subTitle: '描述描述',
+            badge: 999,
+          },
+          {
+            title: '3 Tab',
+            subTitle: '描述',
+          },
+          {
+            title: '4 Tab',
+            subTitle: '描述',
+          },
+          {
+            title: '151111 Tab',
+            subTitle: '描述',
+          },
+          {
+            title: '42345 Tab',
+            subTitle: '描述',
+          },
+          {
+            title: '1511116787 Tab',
+            subTitle: '描述',
+          },
+          {
+            title: '42452 Tab',
+            subTitle: '描述',
+          },
+          {
+            title: '15451111 Tab',
+          },
+          {
+            title: '4234 Tab',
+            subTitle: '描述',
+          },
+          {
+            title: '11251111 Tab',
+            subTitle: '描述',
+          },
+          {
+            title: '44123 Tab',
+          },
+          {
+            title: '1531111 Tab',
+            subTitle: '描述',
+          },
+          {
+            title: '41 Tab',
+          },
+          {
+            title: '15111111 Tab',
+          },
+        ],
+      });
+    }
+  },
+  // 【配置】type 类型选择
+  tabsTypeChange(e) {
+    this.setData({
+      type: e.detail.value,
+    });
+  },
+  // 【配置】animation 类型的选择
+  tabsAnimationChange(e) {
+    this.setData({
+      animation: e.detail.value,
+    });
+  },
+  // 【配置】swipeable 类型的选择
+  tabsSwipeableChange(e) {
+    this.setData({
+      swipeable: e.detail.value,
+    });
+  },
+  // 【配置】titleSlot 类型的选择
+  tabsTitleSlotScopeChange(e) {
+    this.setData({
+      titleSlot: e.detail.value,
+    });
+  },
+  // 【配置】plusSlot 类型的选择
+  tabsPlusSlotScopeChange(e) {
+    this.setData({
+      plusSlot: e.detail.value,
+    });
+  },
+  // 【配置】sticky 类型的选择
+  tabsStickyChange(e) {
+    this.setData({
+      sticky: e.detail.value,
+    });
+  },
+  // tabs 的点击回调
+  changeTab(e) {
+    this.setData({
+      index: e,
+    });
+  },
+  // 右上角的 plus 区域点击事件
+  iconClick() {
+    my.alert({
+      title: 'slot="plus"',
+      content: '自定义 slot 的 icon 被点击',
+    });
+  },
+});

--- a/demo/pages/TabsSticky/index.json
+++ b/demo/pages/TabsSticky/index.json
@@ -1,0 +1,8 @@
+{
+    "defaultTitle": "Tabs",
+    "usingComponents": {
+      "tabs": "../../../src/Tabs/index",
+      "tab-content": "../../../src/Tabs/TabItem/index",
+      "icon": "../../../src/Icon/index"
+    }
+  }

--- a/src/Mask/index.md
+++ b/src/Mask/index.md
@@ -1,0 +1,46 @@
+---
+nav:
+  path: /components
+group:
+  title: 其他
+toc: false
+---
+
+# Mask
+加载，用于提示局部或页面在加载中。
+## API 
+
+
+### 属性 
+
+
+| 属性 | 类型 | 必填 | 默认值 | 说明 |
+| -----|-----|-----|-----|----- |
+| maskZindex | string | - | - |  |
+| type | 'product' &verbar; 'market' | - | - |  |
+| show | boolean | - | - |  |
+| fixMaskFull | false | - | - |  |
+| className | string | - | - | 类名 |
+
+### 事件 
+
+
+| 事件名 | 说明 | 类型 |
+| -----|-----|----- |
+| onMaskTap |  | (v: Record<string, any>) => void |
+
+### CSS 变量 
+
+| CSS 变量名称 | 说明 |
+| -----|----- |
+| --am-mask-backgroundColor | - |
+| --am-mask-market-backgroundColor | - |
+### 样式类 
+
+| 类名 | 说明 |
+| -----|----- |
+| amd-mask | - |
+| amd-mask__m | - |
+| amd-mask__fix | - |
+
+

--- a/src/Tabs/TabItem/index.axml
+++ b/src/Tabs/TabItem/index.axml
@@ -1,8 +1,23 @@
-<view a:if="{{!component2}}" class="amd-tabs-item amd-tabs-item-pane {{className ? className : ''}}"
-  key="tabs-pane-{{$id}}" style="align-self: flex-start;">
-  <slot />
-</view>
-<view a:else style="{{style}}"
-  class="amd-tabs-item amd-tabs-item-pane amd-tabs-item-swiper {{className ? className : ''}}" key="tabs-item-{{$id}}">
-  <slot />
-</view>
+<block  a:if="{{fallback}}" >
+  <view  
+    style="{{style}}"
+    class="amd-tabs-item amd-tabs-item-pane {{className ? className : ''}}" 
+    key="tabs-item-{{$id}}">
+      <slot />
+  </view>
+</block>
+<block a:else>
+  <view 
+    a:if="{{!component2}}" 
+    class="amd-tabs-item amd-tabs-item-pane {{className ? className : ''}}"
+    key="tabs-pane-{{$id}}" 
+    style="align-self: flex-start;">
+    <slot />
+  </view>
+  <view 
+    a:else 
+    style="{{style}}"
+    class="amd-tabs-item amd-tabs-item-pane amd-tabs-item-swiper {{className ? className : ''}}" key="tabs-item-{{$id}}">
+    <slot />
+  </view>
+</block>

--- a/src/Tabs/TabItem/index.axml
+++ b/src/Tabs/TabItem/index.axml
@@ -1,23 +1,14 @@
-<block  a:if="{{fallback}}" >
-  <view  
-    style="{{style}}"
-    class="amd-tabs-item amd-tabs-item-pane {{className ? className : ''}}" 
-    key="tabs-item-{{$id}}">
-      <slot />
-  </view>
-</block>
-<block a:else>
-  <view 
-    a:if="{{!component2}}" 
-    class="amd-tabs-item amd-tabs-item-pane {{className ? className : ''}}"
-    key="tabs-pane-{{$id}}" 
-    style="align-self: flex-start;">
+<view  
+  a:if="{{fallback}}"
+  style="{{style ? style : 'width:100%'}}"
+  class="{{className}}" 
+  key="tabs-item-{{$id}}">
     <slot />
-  </view>
-  <view 
-    a:else 
-    style="{{style}}"
-    class="amd-tabs-item amd-tabs-item-pane amd-tabs-item-swiper {{className ? className : ''}}" key="tabs-item-{{$id}}">
+</view>
+<view 
+  a:else
+  class="amd-tabs-item amd-tabs-item-pane {{ !isBaseSwiper ? '' : 'amd-tabs-item-swiper'}} {{className ? className : ''}}"
+  key="tabs-pane-{{$id}}" 
+  style="{{ !isBaseSwiper ? 'align-self: flex-start' : style }}">
     <slot />
-  </view>
-</block>
+</view>

--- a/src/Tabs/TabItem/index.axml
+++ b/src/Tabs/TabItem/index.axml
@@ -1,14 +1,13 @@
-<view  
-  a:if="{{fallback}}"
-  style="{{style ? style : 'width:100%'}}"
-  class="{{className}}" 
-  key="tabs-item-{{$id}}">
-    <slot />
+<view a:if="{{!isBaseSwiper}}" 
+  class="amd-tabs-item amd-tabs-item-pane {{className ? className : ''}}"
+  key="tabs-pane-{{$id}}" 
+  style="align-self: flex-start;">
+  <slot />
 </view>
 <view 
-  a:else
-  class="amd-tabs-item amd-tabs-item-pane {{ !isBaseSwiper ? '' : 'amd-tabs-item-swiper'}} {{className ? className : ''}}"
-  key="tabs-pane-{{$id}}" 
-  style="{{ !isBaseSwiper ? 'align-self: flex-start' : style }}">
-    <slot />
+  a:else 
+  style="{{style}}" 
+  class="{{fallback ? '' : 'amd-tabs-item amd-tabs-item-pane amd-tabs-item-swiper'}} {{className ? className : ''}}" 
+  key="tabs-item-{{$id}}">
+  <slot />
 </view>

--- a/src/Tabs/TabItem/index.ts
+++ b/src/Tabs/TabItem/index.ts
@@ -2,14 +2,14 @@ import { TabItemDefaultProps } from './props';
 import { getTabArray, componentContext, componentContextFallback } from '../context';
 import { log } from '../../_util/console';
 import { objectValues } from '../../_util/tools';
+import { compareVersion } from '../../_util/compareVersion';
 
 let n = 0;
-const component2 = my.canIUse('component2');
-
+const isBaseSwiper = compareVersion(my.SDKVersion,'2.0.0');
 Component({
   props: TabItemDefaultProps,
   data: {
-    component2,
+    isBaseSwiper,
     fallback: false
   },
   didMount() {

--- a/src/Tabs/TabItem/index.ts
+++ b/src/Tabs/TabItem/index.ts
@@ -1,5 +1,5 @@
 import { TabItemDefaultProps } from './props';
-import { getTabArray, componentContext } from '../context';
+import { getTabArray, componentContext, componentContextFallback } from '../context';
 import { log } from '../../_util/console';
 import { objectValues } from '../../_util/tools';
 
@@ -10,9 +10,15 @@ Component({
   props: TabItemDefaultProps,
   data: {
     component2,
+    fallback: false
   },
   didMount() {
     this._getTabInfo('didMount');
+    componentContextFallback.onUpdate(v => {
+      this.setData({
+        fallback: v
+      })
+    })
   },
   didUpdate() {
     this._getTabInfo();

--- a/src/Tabs/context.ts
+++ b/src/Tabs/context.ts
@@ -1,5 +1,5 @@
 import { ComponentContext } from '../_util/context';
 
 export const componentContext = new ComponentContext();
-
+export const componentContextFallback = new ComponentContext();
 export const getTabArray = {};

--- a/src/Tabs/index.axml
+++ b/src/Tabs/index.axml
@@ -1,5 +1,6 @@
 <view class="amd-tabs {{className ? className : ''}}">
-  <view class="amd-tabs-bar {{type === 'basis'?'amd-tabs-bar-underline':''}} {{sticky ?'amd-tabs-bar-sticky':''}}">
+  <view class="amd-tabs-bar {{type === 'basis'?'amd-tabs-bar-underline':''}}"
+    style="{{sticky ? `position: sticky; top: ${stickyTop}; z-index: 999;`: ''}}">
     <view class="amd-tabs-bar-plus">
       <slot name="plus" />
     </view>
@@ -17,7 +18,7 @@
       <!-- onAppear 控制阴影显示/隐藏 「左」 -->
       <view class="amd-tabs-bar-item-placeholder"
         onAppear="appearLeft"
-        onDisappear="disappearLeft">.</view>
+        onDisappear="disappearLeft"></view>
       <view a:for="{{_tabs}}" key="{{item.title}}" class="amd-tabs-bar-wrap {{`amd-tabs-bar-wrap-${type}`}}">
           <!-- basis 基础类型 -->
           <view 
@@ -59,7 +60,7 @@
       <!-- onAppear 控制阴影显示/隐藏「右」-->
       <view class="amd-tabs-bar-item-placeholder"
         onAppear="appearRight"
-        onDisappear="disappearRight">.</view>
+        onDisappear="disappearRight"></view>
     </scroll-view>
   </view>
     <view a:if="{{component2}}" style="{{_tabContentHeight ? `height: ${_tabContentHeight}px;`: ''}}">

--- a/src/Tabs/index.axml
+++ b/src/Tabs/index.axml
@@ -76,7 +76,9 @@
         id="amd-tabs-content-{{$id}}"
         class="amd-tabs-content {{_tabContentHeight ? 'amd-tabs-content_H100': ''}}"
         adjust-height='current'
-        onChange="handleSwiperChange">
+        onChange="handleSwiperChange"
+        onTouchStart="handleSwiperTouchStart"
+        onTransition="handleSwiperTransition">
         <!--2.7.5 及以上自适应高度；2.6.4 - 2.7.4 强制刷新；2.6.4 一下只能手动查询高度-->
         {{isForceUpdate ? _forceRefreshSwiper : ''}}
         <slot />
@@ -92,7 +94,7 @@
         <slot />
       </view>
     </view>
-    
+
     <!--fallback 用户自己控制显示选项 -->
     <view a:elif="{{fallback}}" class="amd-tabs-content">
         <slot />

--- a/src/Tabs/index.axml
+++ b/src/Tabs/index.axml
@@ -63,7 +63,8 @@
         onDisappear="disappearRight"></view>
     </scroll-view>
   </view>
-    <view a:if="{{component2}}" style="{{_tabContentHeight ? `height: ${_tabContentHeight}px;`: ''}}">
+    <!--2.0 不支持 adjust-content，用丐版 swiper 代替-->
+    <view a:if="{{ !fallback && isBaseSwiper}}" style="{{_tabContentHeight ? `height: ${_tabContentHeight}px;`: ''}}">
       <swiper circular="{{false}}"
         indicator-dots="{{false}}"
         current="{{currentIndex}}"
@@ -81,7 +82,7 @@
         <slot />
       </swiper>
     </view>
-    <view a:else class="amd-tabs-content">
+    <view a:elif="{{!fallback && !isBaseSwiper}}" class="amd-tabs-content">
       <view class="amd-tabs-slides {{currentIndex === index?'amd-tabs-slides-height':''}}"
         id="amd-tabs-content-{{$id}}"
         style="
@@ -90,5 +91,10 @@
       ">
         <slot />
       </view>
+    </view>
+    
+    <!--fallback 用户自己控制显示选项 -->
+    <view a:elif="{{fallback}}" class="amd-tabs-content">
+        <slot />
     </view>
 </view>

--- a/src/Tabs/index.axml
+++ b/src/Tabs/index.axml
@@ -84,7 +84,7 @@
         <slot />
       </swiper>
     </view>
-    <view a:else class="{{ fallback ? '' : amd-tabs-content }}">
+    <view a:else class="{{ fallback ? '' : 'amd-tabs-content' }}">
       <view class = "{{ fallback ? '' : 'amd-tabs-slides'}} {{ currentIndex === index ? 'amd-tabs-slides-height' :''}}"
         id="amd-tabs-content-{{$id}}"
         style="{{ fallback 

--- a/src/Tabs/index.axml
+++ b/src/Tabs/index.axml
@@ -78,7 +78,7 @@
         onChange="handleSwiperChange"
         onTouchStart="handleSwiperTouchStart"
         onTransition="handleSwiperTransition"
-        touch-angle="touchAngle">
+        touch-angle="{{touchAngle}}">
         <!--2.7.5 及以上自适应高度；2.6.4 - 2.7.4 强制刷新；2.6.4 一下只能手动查询高度-->
         {{isForceUpdate ? _forceRefreshSwiper : ''}}
         <slot />

--- a/src/Tabs/index.axml
+++ b/src/Tabs/index.axml
@@ -77,7 +77,8 @@
         adjust-height='current'
         onChange="handleSwiperChange"
         onTouchStart="handleSwiperTouchStart"
-        onTransition="handleSwiperTransition">
+        onTransition="handleSwiperTransition"
+        touch-angle="touchAngle">
         <!--2.7.5 及以上自适应高度；2.6.4 - 2.7.4 强制刷新；2.6.4 一下只能手动查询高度-->
         {{isForceUpdate ? _forceRefreshSwiper : ''}}
         <slot />

--- a/src/Tabs/index.axml
+++ b/src/Tabs/index.axml
@@ -68,7 +68,6 @@
       <swiper circular="{{false}}"
         indicator-dots="{{false}}"
         current="{{currentIndex}}"
-        interval="99999999"
         duration="{{_swipeableAnimation || animation ? 300 : 1}}"
         autoplay="{{false}}"
         disable-touch="{{_swipeable}}"
@@ -84,19 +83,14 @@
         <slot />
       </swiper>
     </view>
-    <view a:elif="{{!fallback && !isBaseSwiper}}" class="amd-tabs-content">
-      <view class="amd-tabs-slides {{currentIndex === index?'amd-tabs-slides-height':''}}"
+    <view a:else class="{{ fallback ? '' : amd-tabs-content }}">
+      <view class = "{{ fallback ? '' : 'amd-tabs-slides'}} {{ currentIndex === index ? 'amd-tabs-slides-height' :''}}"
         id="amd-tabs-content-{{$id}}"
-        style="
-        transform: translate3d({{-currentIndex * 100}}%, 0, 0);
-        transition-duration: {{animation?'300ms':''}}; {{_tabContentHeight?`height: ${_tabContentHeight}px;`:'height: auto;'}}
-      ">
+        style="{{ fallback 
+          ? ''
+          : `transform: translate3d(${-currentIndex * 100}%, 0, 0); transition-duration: ${animation?'300ms':''}; ${_tabContentHeight?`height: ${_tabContentHeight}px;`:'height: auto;'}`
+        }}">
         <slot />
       </view>
-    </view>
-
-    <!--fallback 用户自己控制显示选项 -->
-    <view a:elif="{{fallback}}" class="amd-tabs-content">
-        <slot />
     </view>
 </view>

--- a/src/Tabs/index.less
+++ b/src/Tabs/index.less
@@ -27,10 +27,8 @@
         background: linear-gradient(90deg,#fff,hsla(0,0%,100%,0));
       }
       &-right {
-        // right: 0;
         right: 104 * @rpx;
-        mask-image: linear-gradient(to left, rgb(0 0 0 / 100%), rgb(255 255 255 / 0%));
-        mask-image: linear-gradient(to left, rgb(0 0 0 / 100%), rgb(255 255 255 / 0%));
+        background: linear-gradient(270deg,#fff,hsla(0,0%,100%,0));
       }
     }
     &-plus {

--- a/src/Tabs/index.less
+++ b/src/Tabs/index.less
@@ -19,25 +19,24 @@
       top: 0;
       bottom: 0;
       z-index: 9;
-      width: 72 * @pixelSize;
+      width: 72 * @rpx;
       background-color: @tabs-inverse-color;
       pointer-events: none;
       &-left {
         left: 0;
-        mask-image: linear-gradient(to right, rgb(0 0 0 / 100%), rgb(255 255 255 / 0%));
-        mask-image: linear-gradient(to right, rgb(0 0 0 / 100%), rgb(255 255 255 / 0%));
+        background: linear-gradient(90deg,#fff,hsla(0,0%,100%,0));
       }
       &-right {
         // right: 0;
-        right: 104rpx;
+        right: 104 * @rpx;
         mask-image: linear-gradient(to left, rgb(0 0 0 / 100%), rgb(255 255 255 / 0%));
         mask-image: linear-gradient(to left, rgb(0 0 0 / 100%), rgb(255 255 255 / 0%));
       }
     }
     &-plus {
       display: flex;
-      width: 88rpx;
-      height: 88rpx;
+      width: 88 * @rpx;
+      height: 88 * @rpx;
       align-self: center;
       align-items: center;
       justify-content: center;
@@ -91,8 +90,8 @@
       white-space: nowrap;
       color: @tabs-basis-color;
       &-placeholder {
-        flex: 0 2rpx;
-        width: 2rpx;
+        flex: 0 2 * @rpx;
+        width: 2 * @rpx;
         height: 100%;
         color: @tabs-inverse-color;
         background-color: @tabs-inverse-color;

--- a/src/Tabs/index.less
+++ b/src/Tabs/index.less
@@ -14,11 +14,6 @@
     &-underline {
       border-bottom: @border-width-standard solid @color-divider-line;
     }
-    &-sticky {
-      position: sticky;
-      top: 0;
-      z-index: 99;
-    }
     &-fade {
       position: absolute;
       top: 0;

--- a/src/Tabs/index.md
+++ b/src/Tabs/index.md
@@ -12,6 +12,8 @@ toc: false
 ## 注意事项
 
 - 目前仅支持一个页面中使用一次 **Tabs** 组件；
+- 在基础库 2.x 版本下，内嵌 scroll-view 产生 scroll-view 无法滚动的情况，建议scroll-view 阻止 touch 事件冒泡：catchTouchStart、catchTouchMove。详见[官方文档](https://opendocs.alipay.com/mini/component/scroll-view)
+- Tabs 内部使用 transform 样式以进行轮播，会导致内嵌弹层显示问题，建议内部不嵌套包含弹层的组件或者使用 fallback 属性，以自己实现简单版的“轮播”，详见下方 fallback 的 demo。
 
 ## 代码示例
 <code src='../../demo/pages/Tabs'></code>

--- a/src/Tabs/index.md
+++ b/src/Tabs/index.md
@@ -16,6 +16,9 @@ toc: false
 ## 代码示例
 <code src='../../demo/pages/Tabs'></code>
 
+### fallback
+<code src='../../demo/pages/TabsFallback'></code>
+
 ## API
 
 ### 属性

--- a/src/Tabs/index.ts
+++ b/src/Tabs/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { TabsDefaultProps } from './props';
-import { getTabArray, componentContext } from './context';
+import { getTabArray, componentContext, componentContextFallback } from './context';
 import { log } from '../_util/console';
 import { objectValues } from '../_util/tools';
 import { compareVersion } from '../_util/compareVersion';
@@ -47,6 +47,7 @@ Component({
         _tabs: value,
       });
     });
+    componentContextFallback.update(this.props.fallback)
     const { index, animation } = this.props;
     this.setData({
       _tabs: objectValues(getTabArray),
@@ -95,7 +96,11 @@ Component({
     }
   },
   didUpdate(prevProps, prevData) {
-    const { index, animation } = this.props;
+    const { index, animation,fallback } = this.props;
+    
+    if(prevProps.fallback !== fallback){
+      componentContextFallback.update(fallback)
+    }
 
     if (prevProps.index !== index && prevData.currentIndex === this.data.currentIndex) {
       this._getTabsWidth();
@@ -213,6 +218,18 @@ Component({
         // 获取当前元素的 offsetLeft 值
         this.currentLeft = e?.currentTarget?.offsetLeft;
         return onChange(index);
+      }
+    },
+    handleSwiperTouchStart(e){
+      const {onTouchStart} = this.props;
+      if(typeof onTouchStart==="function"){
+        onTouchStart(e)
+      }
+    },
+    handleSwiperTransition(e){
+      const {onTransition} = this.props;
+      if(typeof onTransition==="function"){
+        onTransition(e)
       }
     },
     appearLeft() {

--- a/src/Tabs/index.ts
+++ b/src/Tabs/index.ts
@@ -63,9 +63,10 @@ Component({
         .select(`#amd-tabs-bar-item-${index}`)
         .boundingClientRect()
         .exec((ret) => {
-          if (!(<IBoundingClientRect>ret[0])) {
+          if (!ret || !ret[0]) {
             // 当获取到的索引值无法匹配时显示错误提示
-            return log.error('Tabs', `激活的索引值错误，请确认 ${index} 是否为正确的索引值。`);
+            log.error('Tabs', `激活的索引值错误，请确认 ${index} 是否为正确的索引值。`);
+            return 
           }
 
           const { _tabsViewportWidth } = this.data;
@@ -110,9 +111,10 @@ Component({
         .select(`#amd-tabs-bar-item-${index}`)
         .boundingClientRect()
         .exec((ret) => {
-          if (!(<IBoundingClientRect>ret[0])) {
+          if (!ret || !ret[0]) {
             // 当获取到的索引值无法匹配时显示错误提示
-            return log.error('Tabs', `激活的索引值错误，请确认 ${index} 是否为正确的索引值。`);
+            log.error('Tabs', `激活的索引值错误，请确认 ${index} 是否为正确的索引值。`);
+            return;
           }
 
           let { _tabsViewportWidth } = this.data;

--- a/src/Tabs/index.ts
+++ b/src/Tabs/index.ts
@@ -16,6 +16,8 @@ const isForceUpdate = compareVersion(my.SDKVersion, '2.6.4') >= 0 && compareVers
 
 const isMoreThan275 = compareVersion(my.SDKVersion, '2.7.5') >= 0;
 
+const isBaseSwiper = compareVersion(my.SDKVersion, '2.0.0') >= 0;
+
 Component({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   props: TabsDefaultProps,
@@ -31,6 +33,7 @@ Component({
     _tabContentHeight: 0,
     currentIndex: 0,
     component2,
+    isBaseSwiper,
     _forceRefreshSwiper: 0,
     _isForceUpdate: isForceUpdate,
   },

--- a/src/Tabs/index.ts
+++ b/src/Tabs/index.ts
@@ -63,30 +63,31 @@ Component({
         .select(`#amd-tabs-bar-item-${index}`)
         .boundingClientRect()
         .exec((ret) => {
-          const { _tabsViewportWidth } = this.data;
           if (!(<IBoundingClientRect>ret[0])) {
             // 当获取到的索引值无法匹配时显示错误提示
-            log.error('Tabs', `激活的索引值错误，请确认 ${index} 是否为正确的索引值。`);
-          } else {
-            // 正确的索引值在初次加载时高亮展示当前 tab
-            // eslint-disable-next-line no-lonely-if
-            if ((<IBoundingClientRect>ret[0]).left > _tabsViewportWidth / 2) {
-              this.setData({
-                _scrollLeft:
+            return log.error('Tabs', `激活的索引值错误，请确认 ${index} 是否为正确的索引值。`);
+          }
+
+          const { _tabsViewportWidth } = this.data;
+          // 正确的索引值在初次加载时高亮展示当前 tab
+          // eslint-disable-next-line no-lonely-if
+          if ((<IBoundingClientRect>ret[0]).left > _tabsViewportWidth / 2) {
+            this.setData({
+              _scrollLeft:
                 (<IBoundingClientRect>ret[0]).left -
                 _tabsViewportWidth / 2 +
                 (<IBoundingClientRect>ret[0]).width / 2,
-                _leftFade: true,
-                _swipeableAnimation: animation,
-              });
-            } else {
-              this.setData({
-                _scrollLeft: 0,
-                _leftFade: false,
-                _swipeableAnimation: animation,
-              });
-            }
+              _leftFade: true,
+              _swipeableAnimation: animation,
+            });
+          } else {
+            this.setData({
+              _scrollLeft: 0,
+              _leftFade: false,
+              _swipeableAnimation: animation,
+            });
           }
+
         });
       this._autoHeight(index);
     }
@@ -96,9 +97,9 @@ Component({
     }
   },
   didUpdate(prevProps, prevData) {
-    const { index, animation,fallback } = this.props;
-    
-    if(prevProps.fallback !== fallback){
+    const { index, animation, fallback } = this.props;
+
+    if (prevProps.fallback !== fallback) {
       componentContextFallback.update(fallback)
     }
 
@@ -109,36 +110,37 @@ Component({
         .select(`#amd-tabs-bar-item-${index}`)
         .boundingClientRect()
         .exec((ret) => {
+          if (!(<IBoundingClientRect>ret[0])) {
+            // 当获取到的索引值无法匹配时显示错误提示
+            return log.error('Tabs', `激活的索引值错误，请确认 ${index} 是否为正确的索引值。`);
+          }
+
           let { _tabsViewportWidth } = this.data;
           _tabsViewportWidth = Math.floor(_tabsViewportWidth);
           let left = Math.floor((<IBoundingClientRect>ret[0]).left) + this.data._scrollLeft;
           const width = Math.floor((<IBoundingClientRect>ret[0]).width);
 
-          if (!(<IBoundingClientRect>ret[0])) {
-            // 当获取到的索引值无法匹配时显示错误提示
-            log.error('Tabs', `激活的索引值错误，请确认 ${index} 是否为正确的索引值。`);
-          } else {
-            // 正确的索引值在初次加载时高亮展示当前 tab
-            if (this.changeTap) {
-              left = this.currentLeft;
-              this.changeTap = false;
-            }
-            if (left > _tabsViewportWidth / 2) {
-              this.setData({
-                _scrollLeft: left - _tabsViewportWidth / 2 + width / 2,
-                _leftFade: true,
-                currentIndex: index,
-                _swipeableAnimation: animation,
-              });
-            } else {
-              this.setData({
-                _scrollLeft: 0,
-                _leftFade: false,
-                currentIndex: index,
-                _swipeableAnimation: animation,
-              });
-            }
+          // 正确的索引值在初次加载时高亮展示当前 tab
+          if (this.changeTap) {
+            left = this.currentLeft;
+            this.changeTap = false;
           }
+          if (left > _tabsViewportWidth / 2) {
+            this.setData({
+              _scrollLeft: left - _tabsViewportWidth / 2 + width / 2,
+              _leftFade: true,
+              currentIndex: index,
+              _swipeableAnimation: animation,
+            });
+          } else {
+            this.setData({
+              _scrollLeft: 0,
+              _leftFade: false,
+              currentIndex: index,
+              _swipeableAnimation: animation,
+            });
+          }
+
         });
       this._autoHeight(index);
     }
@@ -151,6 +153,7 @@ Component({
   methods: {
     _autoHeight(tabIndex) {
       if (isShouldNotCalHeight) return;
+      if (this.props.fallback) return
       // tabItem 自适应高度的处理
       // 获取每个 item-pane 的高度，通过传入当前 tab 的 index 值
       // 动态修改 _tabContentHeight 后在 axml 中插入修改
@@ -158,9 +161,11 @@ Component({
         .selectAll(`#amd-tabs-content-${this.$id} .amd-tabs-item-pane`)
         .boundingClientRect()
         .exec((ret) => {
-          this.setData({
-            _tabContentHeight: (<IBoundingClientRect>ret[0])[tabIndex]?.height,
-          });
+          if (ret && ret[0]) {
+            this.setData({
+              _tabContentHeight: (<IBoundingClientRect>ret[0])[tabIndex]?.height,
+            });
+          }
         });
     },
     handleSwiperChange(e) {
@@ -202,9 +207,11 @@ Component({
         .select(`#amd-tabs-bar-scroll-view-${this.$id}`)
         .boundingClientRect()
         .exec((ret) => {
-          this.setData({
-            _tabsViewportWidth: (<IBoundingClientRect>ret[0]).width,
-          });
+          if (ret && ret[0]) {
+            this.setData({
+              _tabsViewportWidth: (<IBoundingClientRect>ret[0]).width,
+            });
+          }
         });
     },
     onChange(e) {
@@ -220,15 +227,15 @@ Component({
         return onChange(index);
       }
     },
-    handleSwiperTouchStart(e){
-      const {onTouchStart} = this.props;
-      if(typeof onTouchStart==="function"){
+    handleSwiperTouchStart(e) {
+      const { onTouchStart } = this.props;
+      if (typeof onTouchStart === "function") {
         onTouchStart(e)
       }
     },
-    handleSwiperTransition(e){
-      const {onTransition} = this.props;
-      if(typeof onTransition==="function"){
+    handleSwiperTransition(e) {
+      const { onTransition } = this.props;
+      if (typeof onTransition === "function") {
         onTransition(e)
       }
     },
@@ -266,7 +273,8 @@ Component({
     return isMoreThan275 ?
       { getCompInstance: () => this }
       :
-      { getCompInstance: () => this,
+      {
+        getCompInstance: () => this,
         updateHeight,
       };
   },

--- a/src/Tabs/props.d.ts
+++ b/src/Tabs/props.d.ts
@@ -1,9 +1,9 @@
 
 import { IBaseProps } from '../_base';
+
 /**
  * @description 标签栏，内部配合 TabItem 使用。
  */
-
 export interface ITabsProps extends IBaseProps {
   /**
    * @description 类型，basis(基础)，capsule(胶囊)，mixin(混合)
@@ -14,29 +14,45 @@ export interface ITabsProps extends IBaseProps {
    * @description 当前激活的索引
    * @default 0
    */
-
   index?: number;
   /**
    * @description tab 切换时的回调
    */
-
   onChange?: (index: number) => void;
   /**
    * @description 是否有过渡动画
    * @default false
    */
-
   animation?: boolean;
   /**
    * @description 是否支持手势切换
    * @default false
    */
   swipeable?: boolean;
-
   /**
    * @description 是否支持吸顶
    * @default false
    */
   sticky?: boolean;
+  /**
+   * @description 吸顶高度
+   * @default 0
+   */
+  stickyTop?: boolean;
+  /**
+   * @description 内部 swiper 组件的 onTouchStart 事件（仅在基础库 2.x 版本生效）
+   * @default 0
+   */
+  onTouchStart?: (e:any) => void;
+  /**
+   * @description 内部 swiper 组件的 onTouchStart 事件（仅在基础库 2.x 版本下生效）
+   * @default 0
+   */
+  onTransition?: (e:any) => void;
+  /**
+   * @description 是否自定义实现"轮播"，详见 fallback demo
+   * @default 0
+   */
+  fallback?: boolean;
 }
 export declare const TabsDefaultProps: Partial<ITabsProps>;

--- a/src/Tabs/props.d.ts
+++ b/src/Tabs/props.d.ts
@@ -54,5 +54,10 @@ export interface ITabsProps extends IBaseProps {
    * @default 0
    */
   fallback?: boolean;
+  /**
+   * @description 内部 swiper 组件属性 touch-angle。计算用户手势时所依赖的滑动角度。角度根据 touchstart 事件和首次 touchmove 事件的坐标计算得出。数值越小越对用户的滑动方向准确度要求越高。
+   * @default 45
+   */
+  touchAngle?: number;
 }
 export declare const TabsDefaultProps: Partial<ITabsProps>;

--- a/src/Tabs/props.js
+++ b/src/Tabs/props.js
@@ -6,5 +6,6 @@ export const TabsDefaultProps = {
   sticky: false,
   stickyTop: 0,
   fallback:false,
+  touchAngle: 45,
   onGetRef: () => {},
 };

--- a/src/Tabs/props.js
+++ b/src/Tabs/props.js
@@ -4,5 +4,7 @@ export const TabsDefaultProps = {
   animation: false,
   swipeable: false,
   sticky: false,
+  stickyTop: 0,
+  fallback:false,
   onGetRef: () => {},
 };


### PR DESCRIPTION
修复 adjust-content 在基础库 1.x 下的问题
- 2.x 下内部采用 swiper 基础组件
- 1.x 下内部采用 view + transform 实现一个简版的”swiper“
- 由于 swiper 基础组件与 view + transform 的方案，使得用户在 Tabs 内使用 Modal 这类组件时，蒙层被压住，无法覆盖整屏。因此，提供 fallback api，让用户自己去实现这类”swiper“。
