### PR TITLE
fix(compile): replace babel with tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "async-validator": "^4.0.7",
-    "fast-deep-equal": "3.1.3"
+    "fast-deep-equal": "3.1.3",
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@babel/code-frame": "^7.0.0",
@@ -47,6 +48,7 @@
     "@babel/preset-typescript": "^7.6.0",
     "@babel/traverse": "^7.0.0",
     "@babel/types": "^7.0.0",
+    "@mini-types/alipay": "^1.0.8",
     "@types/acorn": "^4.0.6",
     "@types/babel__code-frame": "^7.0.0",
     "@types/babel__core": "^7.0.0",
@@ -57,7 +59,6 @@
     "@types/jest": "^27.4.0",
     "@types/less": "^3.0.3",
     "@types/marked": "^4.0.2",
-    "@mini-types/alipay": "^1.0.8",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
     "acorn": "^8.7.0",
@@ -83,6 +84,7 @@
     "gulp-inject-envs": "^1.0.0",
     "gulp-less": "^5.0.0",
     "gulp-rename": "^1.2.3",
+    "gulp-typescript": "^6.0.0-alpha.1",
     "inquirer": "^8.2.1",
     "jest": "^27.5.1",
     "less": "^4.1.2",

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -7,6 +7,7 @@ const cleanCss = require('gulp-clean-css');
 const babel = require('gulp-babel');
 const gulpif = require('gulp-if');
 const injectEnvs = require('gulp-inject-envs');
+const ts = require('gulp-typescript');
 
 const isProduction = process.env.NODE_ENV === 'production';
 const dist = isProduction ? path.join(__dirname, '../es') : path.join(__dirname, '../demo/es');
@@ -48,8 +49,14 @@ gulp.task('sjs', () => gulp.src(`${src}/**/*.sjs`)
 gulp.task('ts', () => gulp.src(`${src}/**/*.ts`)
   .pipe(gulpif((file) => {
     return !file.path.endsWith('.d.ts');
-  }, babel({
-    presets:['@babel/preset-env']
+  }, ts({
+    noEmitOnError:false,
+    isolatedModules:true,
+    importHelpers: true,
+    esModuleInterop: true,
+    noImplicitThis: true,
+    allowSyntheticDefaultImports: true,
+    target: 'ES5'
   })))
   .pipe(injectEnvs(env))
   .on('error', (err) => {


### PR DESCRIPTION
用户在开发钉钉小程序时，使用 antd-mini 遇见 [babel 报错](https://github.com/facebook/regenerator/issues/373)。
现改为 tsc 编译以绕过此问题。