### PR TITLE
fix(Form): fix Form in plugin mode

### DIFF
--- a/src/Form/FormItem/index.ts
+++ b/src/Form/FormItem/index.ts
@@ -25,7 +25,7 @@ Component({
     }
   },
   didMount() {
-    this.data.setData = this.$page.data._currentSetData;
+    this.data.setData = this.$page._currentSetData;
     if (!this.data.setData) return;
     const { form, name: field } = this.props;
     if (form && field) {

--- a/src/Form/FormItem/index.ts
+++ b/src/Form/FormItem/index.ts
@@ -18,7 +18,7 @@ Component({
   onInit() {
     const { form, name: field, rules, initialValue, required } = this.props;
     if (form && field) {
-      this.$page.data._getCurrentField = () => {
+      this.$page._getCurrentField = () => {
         return { form: () => this.props.form, field: () => this.props.name };
       };
       store.bootstrap(form, field, rules, initialValue, required);

--- a/src/Picker/index.ts
+++ b/src/Picker/index.ts
@@ -32,8 +32,8 @@ Component({
         valueIndex: changeValue,
       });
     };
-    if (!this.$page.data._getCurrentField) return;
-    const { form: formFn, field: fieldFn } = this.$page.data._getCurrentField();
+    if (!this.$page._getCurrentField) return;
+    const { form: formFn, field: fieldFn } = this.$page._getCurrentField();
     const form = formFn();
     const field = fieldFn();
     store.addUpdateFiledValue(form, field, updatePickerFiledValue);

--- a/src/mixins/form.ts
+++ b/src/mixins/form.ts
@@ -61,9 +61,9 @@ export default () => {
     },
     didMount() {
       if (isMoreThan106 && isNotFormMode(this.props.mode)) {
-        this.$page.data._currentSetData = null;
+        this.$page._currentSetData = null;
       } else {
-        this.$page.data._currentSetData = this.setData;
+        this.$page._currentSetData = this.setData;
       }
     },
   };

--- a/src/mixins/form.ts
+++ b/src/mixins/form.ts
@@ -31,7 +31,7 @@ export default () => {
     onInit() {
       if (isMoreThan106 && isNotFormMode(this.props.mode)) return;
 
-      const getCurrentField = this.$page.data._getCurrentField;
+      const getCurrentField = this.$page._getCurrentField;
       if (!getCurrentField) return;
       this.props._getCurrentField = getCurrentField;
       const { form: formFn, field: fieldFn } = getCurrentField();

--- a/src/mixins/htmlType.ts
+++ b/src/mixins/htmlType.ts
@@ -8,7 +8,7 @@ export default () => ({
       this.props._submit = () => {
         store.onFinish(() => this.props.form);
       };
-      this.$page.data._getCurrentField = null;
+      this.$page._getCurrentField = null;
     }
   },
 });


### PR DESCRIPTION
### Reason

`this.$page.data` is unavaliable when public component of one plugin is embedded in other page.

### TODO

This resolution is not the final one yet.
The mechanism which share global context by `this.$page` is not solid for multiple form instance.