### PR TITLE
docs(modal): fix typo and markdown table

### DIFF
--- a/src/Modal/index.md
+++ b/src/Modal/index.md
@@ -35,7 +35,7 @@ toc: false
 
 | 事件名 | 说明 | 类型 |
 | -----|-----|-----|
-| onButtonTap | 点击 Modal 组件内部按钮，触发回调 | (type: 'marin' | 'addon' ) => void |
+| onButtonTap | 点击 Modal 组件内部按钮，触发回调 | (type: 'main' \| 'addon' ) => void |
 | onClose | 点击 close 图标触发回调 | () => void |
 
 ## 插槽


### PR DESCRIPTION

brefore:

![image](https://user-images.githubusercontent.com/13745971/165707522-71d8b192-69ea-4a84-9b3d-624bc025ba88.png)

after:

![image](https://user-images.githubusercontent.com/13745971/165707429-02ba3310-0c04-4825-8ca4-b3c54c76d433.png)
