### PR TITLE
feat: add package entry

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.export = {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "antd-mini",
   "version": "0.0.2-alpha.1",
+  "main": "index.js",
   "scripts": {
     "dev": "minidev dev --less --typescript --no-source-map",
     "dev:site": "dumi dev",
@@ -106,7 +107,8 @@
     "yorkie": "^2.0.0"
   },
   "files": [
-    "es"
+    "es",
+    "index.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
package 中没有配置 main 字段，导致 `require.resolve('antd-mini')` 这类 API 报错，找不到包地址。