### PR TITLE
fix(vTabs): fix click bottom tap jump to the tap before

### DIFF
--- a/src/VTabs/index.axml
+++ b/src/VTabs/index.axml
@@ -10,7 +10,7 @@
             payload="{{index}}"
             onTap="onChange">
             <view class="amd-vtabs-bar-item {{_index - index?'' : 'amd-vtabs-bar-item-active'}} {{item.disabled?'amd-vtabs-bar-item-disabled' : '' }}"
-              style="{{_index + 1 === index ? 'border-radius: 0 16rpx 0 0': ''}}"
+              style="{{`${_index + 1 === index ? 'border-radius: 0 16rpx 0 0': ''};${_index - 1 === index ? 'border-radius: 0 0 16rpx 0': ''}`}}"
               >
               <badge a:if="{{item.badge}}" type="{{item.badge.type}}" bubble="{{!!item.badge.bubble}}" text="{{item.badge.text}}">
               <text class="amd-vtabs-bar-item-title">

--- a/src/VTabs/index.ts
+++ b/src/VTabs/index.ts
@@ -123,6 +123,7 @@ Component({
         this.setData({
           wrapScrollTop: { _v: this.indexTop[index] },
         });
+        this.curScrollBarIndex = index;
         this.moveScrollBar(index);
       }
     },
@@ -175,7 +176,9 @@ Component({
           scrollTop < this.anchorMap[keys[i + 1]]) {
           // 如果每个 vtabItem 高度小于 scroll-view 高度，到达底部后就不需要根据 scrollTop 再去判断左侧的选择项
           if (scrollTop + this.wrapHeight < this.scrollWrapHeight) {
-            this.moveScrollBar(i);
+            this.moveScrollBar(this.curScrollBarIndex || i);
+            // 滚动时清空点击左侧bar的数据
+            this.curScrollBarIndex = '';
           }
           break;
         }


### PR DESCRIPTION
- 修复 VTabs tab 过长，点击最后几个 tab 会自动切换到之前的 tab
- 修复 VTabs tab active时，上一个 tab 无 border-radius 样式
- https://github.com/ant-design/ant-design-mini/issues/92