### PR TITLE
fix(CheckboxGroup): remove default value prop

### DIFF
--- a/src/CheckboxGroup/props.js
+++ b/src/CheckboxGroup/props.js
@@ -3,5 +3,4 @@ export const CheckboxGroupDefaultProps = {
   radius: false,
   uid: 'CheckboxGroup',
   controlled: false,
-  value: [],
 };


### PR DESCRIPTION
修复钉钉小程序中使用CheckboxGroup报错 #74 