### PR TITLE
fix: fix FormGroup radius props

### DIFF
--- a/src/Form/FormGroup/index.axml
+++ b/src/Form/FormGroup/index.axml
@@ -1,4 +1,4 @@
-<view class="amd-form-group {{className ? className : ''}}">
+<view class="amd-form-group {{className ? className : ''}} {{radius ? 'amd-form-group-radius' : ''}}">
     <block a:if="{{header}}">
         <view class="amd-form-group-header">
       {{header}}

--- a/src/Form/FormGroup/index.less
+++ b/src/Form/FormGroup/index.less
@@ -21,4 +21,9 @@
     position: relative;
     overflow: hidden;
   }
+  &-radius {
+    & .@{formGroupPrefix}-body {
+      border-radius: 16 * @rpx;
+    }
+  }
 }


### PR DESCRIPTION
修复了FromGroup添加radius属性不生效的问题
<img width="1414" alt="image" src="https://user-images.githubusercontent.com/42140018/168725515-088d40e3-1a97-405a-aabc-6fcb37799dee.png">
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/42140018/168725610-42f3f33b-089d-43a6-8b30-b3be2c54fd7f.png">
