### PR TITLE
feat(videoUpload): support different value type

### DIFF
--- a/demo/pages/VideoUpload/index.axml
+++ b/demo/pages/VideoUpload/index.axml
@@ -4,7 +4,6 @@
     <uploader 
       action="{{action}}"
       value="{{value_1}}"
-      id="myVideo_1"
       maxCount="{{1}}"
       sourceType="{{['album']}}"
       onChange="onChange"
@@ -16,7 +15,6 @@
     <uploader 
       action="{{action}}"
       value="{{value_2}}"
-      id="myVideo_2"
       maxCount="{{6}}"
       onChange="onChange"
     />
@@ -25,8 +23,8 @@
   <view class="demo-video-upload-show">
     <uploader 
       action="{{action}}"
-      id="myVideo_4"
-      maxCount="{{2}}"
+      maxCount="{{4}}"
+      value="{{value_3}}"
       onChange="onChange"
     >
       <view slot="uploadIcon">
@@ -38,7 +36,6 @@
   <view class="demo-video-upload-show">
     <uploader 
       action="{{action}}"
-      id="myVideo_5"
       width="168"
       height="120"
       maxCount="{{2}}"
@@ -49,7 +46,7 @@
   <view class="demo-video-upload-show">
     <uploader 
       action="{{action}}"
-      id="myVideo_6"
+      id="myVideo_5"
       value="{{value_1}}"
       maxCount="{{2}}"
       onDelete="onDelete"
@@ -59,7 +56,6 @@
   <view class="demo-video-upload-show">
     <uploader 
       action="{{action}}"
-      id="myVideo_7"
       value="{{value_1}}"
       maxCount="{{2}}"
       onBeforeUpload="onBeforeUpload"
@@ -68,7 +64,6 @@
   <view class="demo-video-upload-title">自定义上传方法</view>
   <view class="demo-video-upload-show">
     <uploader 
-      id="myVideo_8"
       value="{{value_1}}"
       maxCount="{{2}}"
       onUpload="onUpload"

--- a/demo/pages/VideoUpload/index.js
+++ b/demo/pages/VideoUpload/index.js
@@ -15,7 +15,11 @@ Page({
       url: 'XMzg2Mzc5MzMwMA==',
       status: 'error'
     }],
-    demoVideo: 'XNTg1Njg5NzkwMA=='
+    value_3: [
+      'XNDM0OTQzMDc2OA==',
+      'XMzg2Mzc5MzMwMA==',
+      'XMzg2Mzc5MzMwMA=='
+    ]
   },
   onChange(v) {
     console.log('当前已上传的图片列表：', v);

--- a/src/VideoUpload/index.axml
+++ b/src/VideoUpload/index.axml
@@ -11,7 +11,7 @@
       poster-size="cover" 
       style="{{`height:${height}px;width:${width}px`}}" 
     />
-    <cover-view 
+    <cover-view
       class="amd-video-upload-click-area" 
       a:if="{{item.status === 'done'}}"  
       data-preview-video-url="{{item.localPath || item.url || item.key}}" 
@@ -49,7 +49,7 @@
   </view>
   <!-- 这个video是专门用来做全屏播放用的，其它的都是用来做展示首帧用的 -->
   <video 
-    id="{{id||'myVideo'}}" 
+    id="{{id}}" 
     style="{{width: 0,height: 0}}" 
     src="{{playVideoUrl}}" 
     enable-progress-gesture="{{false}}" 

--- a/src/VideoUpload/index.md
+++ b/src/VideoUpload/index.md
@@ -23,18 +23,17 @@ toc: 'content'
 
 | 属性 | 类型 | 必填 | 默认值 | 说明 |
 | -----|-----|-----|-----|----- |
-| value | File[] | - | [] | 已上传的图片列表 |
-| action | string | - | - | 上传视频的服务器地址，只支持https地址 |
-| camera | string | - | 'back' | 默认拉起的是前置或者后置摄像头，可选值'back'或'front' |
-| filename | string | - | - | 上传视频的文件名，即对应的 key，开发者在服务器端通过这个 key 可以获取到视频二进制内容 |
-| formData | any | - | {} | 上传时其他额外的 form 数据对象。 |
+| value | Array\<File \| string\> \| string | 否 | [] | 已上传的图片列表 |
+| action | string | 否 | - | 上传视频的服务器地址，只支持https地址 |
+| camera | string | 否 | 'back' | 默认拉起的是前置或者后置摄像头，可选值'back'或'front' |
+| filename | string | 否 | - | 上传视频的文件名，即对应的 key，开发者在服务器端通过这个 key 可以获取到视频二进制内容 |
+| formData | any | 否 | {} | 上传时其他额外的 form 数据对象。 |
 | height | number &verbar; string | - | 80 | 自定义容器高度 |
-| id | string | - | - | video播放器标识 |
-| maxCount | number | - | 1 | 上传视频的最大数量 |
-| maxDuration | number | - | 60 | 拍摄视频最长拍摄时间，单位秒。 |
-| sourceType | ['album'] &verbar; ['camera'] &verbar; ['album', 'camera'] | - | ['album', 'camera'] | 视频选择的来源 |
-| width | number &verbar; string | - | 80 | 自定义容器宽度 |
-| className | string | - | - | 类名 |
+| maxCount | number | 否 | 1 | 上传视频的最大数量 |
+| maxDuration | number | 否 | 60 | 拍摄视频最长拍摄时间，单位秒。 |
+| sourceType | ['album'] &verbar; ['camera'] &verbar; ['album', 'camera'] | 否 | ['album', 'camera'] | 视频选择的来源 |
+| width | number &verbar; string | 否 | 80 | 自定义容器宽度 |
+| className | string | 否 | - | 类名 |
 
 ## 事件 
 

--- a/src/VideoUpload/index.ts
+++ b/src/VideoUpload/index.ts
@@ -5,27 +5,51 @@ import { chooseVideo, uploadFile } from '../_util/promisify';
 Component({
   props: VideoUploadDefaultProps,
   data: {
+    id: '',
     fileList: [],
     playVideoUrl: '',
   } as IVideoUploadData,
-  didMount() {
-    const { value, id } = this.props;
 
+  didMount() {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    this.videoContext = my.createVideoContext(id || 'myVideo');
+    this.videoContext = my.createVideoContext(`video_${this.$page.$id}_${this.$id}`);
     this.setData({
-      fileList: value
-    });
+      id: `video_${this.$page.$id}_${this.$id}`
+    })
+    this.handleValue();
   },
+
   didUpdate(prevProps) {
     if (!equal(prevProps.value, this.props.value)) {
-      this.setData({
-        fileList: this.props.value
-      })
+      this.handleValue();
     }
   },
+
   methods: {
+    handleValue() {
+      let curValue;
+      const { value } = this.props;
+
+      if (typeof value === 'string') {
+        curValue = [].concat(value);
+      } else if (
+        Array.isArray(value) &&
+        value.length &&
+        value.some(v => typeof v === 'string')
+      ) {
+        curValue = value.map(v => (typeof v === 'string' ? {
+          url: v,
+          status: 'done'
+        } : v));
+      } else {
+        curValue = value;
+      }
+      this.setData({
+        fileList: curValue
+      });
+    },
+
     async onChooseVideo() {
       const { camera, maxDuration, sourceType } = this.props;
 
@@ -44,6 +68,7 @@ Component({
         })
       }
     },
+
     async uploadFile(file) {
       const { action, filename, formData, onBeforeUpload, onUpload, onAfterUpload } = this.props;
       const { fileList } = this.data;
@@ -121,6 +146,7 @@ Component({
         });
       }
     },
+
     updateFileList(path, status, url?) {
       const { fileList } = this.data;
       const { onChange } = this.props;
@@ -142,6 +168,7 @@ Component({
 
       onChange && onChange.call(this.props, tempFileList);
     },
+
     async onDeleteVideo(e) {
       const { fileList } = this.data;
       const { onDelete, onChange } = this.props;
@@ -158,6 +185,7 @@ Component({
       });
       onChange && onChange.call(this.props, tempFileList);
     },
+
     onPreviewVideo(e) {
       const { previewVideoUrl } = e.target.dataset;
 
@@ -168,11 +196,13 @@ Component({
       });
 
     },
+
     onPlay() {
       this.videoContext.requestFullScreen({
         direction: 0
       });
     },
+
     onFullScreenChange(e) {
       if (!e.detail.fullScreen) {
         this.videoContext.pause();

--- a/src/VideoUpload/props.d.ts
+++ b/src/VideoUpload/props.d.ts
@@ -34,7 +34,7 @@ export interface IVideoUploadProps extends IBaseProps {
    * @description 默认已上传的视频列表
    * @default []
    */
-  value?: File[];
+  value?: Array<File | string> | string;
 
   /**
    * @description 上传视频的服务器地址，只支持https地址
@@ -65,10 +65,6 @@ export interface IVideoUploadProps extends IBaseProps {
   height?: number | string;
 
   /**
-   * @description video播放器标识
-   */
-  id: string;
-  /**
    * @description 上传视频的最大数量
    * @default 1
    */
@@ -95,7 +91,7 @@ export interface IVideoUploadProps extends IBaseProps {
   /**
    * @description 使用action时，视频上传后的回调函数，当上传接口不为默认的{success: true, data: {url: 'xx'}}时使用，返回void则表示上传失败
    */
-   onAfterUpload?: (res) => string | void | Promise<string | void>;
+  onAfterUpload?: (res) => string | void | Promise<string | void>;
 
   /**
    * @description 视频上传前的回调函数，返回 false 可终止视频上传，支持返回 Promise


### PR DESCRIPTION
- 视频上传组件支持不同类型的值，包括 string 、string[] 和 File[]
- 视频上传组件不在依赖外部手动传入id，改为 this.$page.$id + this.$id  作为唯一标识
- 更新对应demo