### PR TITLE
fix: rate组件增加渐变色功能和图标间距功能

### DIFF
--- a/src/Rate/index.axml
+++ b/src/Rate/index.axml
@@ -1,19 +1,26 @@
 <view class="amd-rate-wrapper {{className}} {{ disabled ? 'amd-rate-disabled' : '' }}">
-  <view class="amd-rate-star-wrapper amd-rate-{{$id}}" onTouchMove="handleStarMove" onTouchEnd="handleStarMoveEnd">
-    <view 
-      class="amd-rate-star" 
+  <view class="amd-rate-star-wrapper amd-rate-{{$id}}" 
+    onTouchMove="handleStarMove" 
+    onTouchEnd="handleStarMoveEnd"
+  >
+    <view class="amd-rate-star" 
       a:for="{{maxRate}}" 
-      onTap="handleRateTap"
-      data-rate="{{index + 1}}"
+      onTap="handleRateTap" 
+      data-rate="{{index + 1}}" 
+      style="{{`${gutter || gutter === 0 ? `margin-right: ${gutter}` : ''}; ${size && size !== '0' ? `width: ${size}` : ''}; ${size && size !== '0' ? `height: ${size}` : ''}` }}"
     >
-      <view 
-        class="amd-rate-star-{{ index + 0.5 === rate ? 'half' : (index + 1 > rate) ? 'empty' : 'full' }}-left"
-        data-type="half"
-        style="{{ `${ image ? `-webkit-mask-image: url(${image});` : '' } background-color: ${index + 0.5 === rate ? activeColor : (index + 1 > rate) ? (allowHalf && !image && !inactiveColor && !activeColor ? halfInactiveColor : inactiveColor) : activeColor}`}}"
+      <view class="amd-rate-star-{{ index + 0.5 === rate ? 'half' : (index + 1 > rate) ? 'empty' : 'full' }}-left" data-type="half" 
+        style="{{ 
+          `${ image ? `-webkit-mask-image: url(${image});` : '' } 
+          background: ${index + 0.5 === rate ? activeColor : (index + 1 > rate) ? (allowHalf && !image && !inactiveColor && !activeColor ? halfInactiveColor : inactiveColor) : activeColor}` }}"
       />
-      <view class="amd-rate-star-{{ index + 0.5 === rate ? 'half' : (index + 1 > rate) ? 'empty' : 'full' }}-right"
+      <view 
+        class="amd-rate-star-{{ index + 0.5 === rate ? 'half' : (index + 1 > rate) ? 'empty' : 'full' }}-right"
         data-type="full"
-        style="{{ `${ image ? `-webkit-mask-image: url(${image});` : '' } background-color: ${index + 0.5 === rate ? inactiveColor : (index + 1 > rate) ? inactiveColor : activeColor}`}}"
+        style="{{ 
+          `${ image ? `-webkit-mask-image: url(${image});` : '' }
+          background: ${index + 0.5 === rate ? inactiveColor : (index + 1 > rate) ? inactiveColor : activeColor}
+        `}}"
       />
     </view>
   </view>

--- a/src/Rate/index.md
+++ b/src/Rate/index.md
@@ -23,6 +23,8 @@ toc: false
 | maxRate | number | 否 | 5 | 最大星级 |
 | activeColor | string | 否 | - | 填充色 |
 | inactiveColor | string | 否 | - | 原始填充色 |
+| gutter | number | string | 否 | - | 图标的间距 |
+| size | number | string | 否 | - | 图标的大小 |
 | disabled | boolean | 否 | - | 是否禁用 |
 | image | string | 否 | - | 自定义图片，格式 svg |
 | className | string | 否 | - | 类名 |

--- a/src/Rate/props.d.ts
+++ b/src/Rate/props.d.ts
@@ -42,6 +42,16 @@ export interface IRateProps extends IBaseProps {
   inactiveColor?: string;
 
   /**
+   * @description 图标的间距
+   */
+  gutter?: number | string;
+
+  /**
+   * @description 图标的大小
+   */
+  size?: number | string;
+   
+  /**
    * @description 自定义图片
    */
   image?: string;

--- a/src/Rate/props.js
+++ b/src/Rate/props.js
@@ -1,10 +1,10 @@
 export const RateDefaultProps = {
-    maxRate: 5,
-    initRate: 0,
-    allowHalf: false,
-    readOnly: false,
-    disabled: false,
-    halfInactiveColor: "#DBDBDB",
-    activeColor: '#FFD24A',
-    inactiveColor: '#E5E5E5'
+  maxRate: 5,
+  initRate: 0,
+  allowHalf: false,
+  readOnly: false,
+  disabled: false,
+  halfInactiveColor: "#DBDBDB",
+  activeColor: '#FFD24A',
+  inactiveColor: '#E5E5E5'
 };


### PR DESCRIPTION
feature:
1. 已有参数activeColor填充色支持传入渐变色，例：activeColor="linear-gradient(rgba(0, 0, 255, 0.5), rgba(255, 255, 0, 0.5))"，默认值不变。
2. 新增参数gutter: rate图标间距, 支持类型number、string，类型number时，默认单位px，类型string时，可传入单位px、rpx等，默认值不变。
3. 新增参数 size : rate图标的大小，支持类型number、string，类型number时，默认单位px，类型string时，可传入单位px、rpx等，默认值不变。