### PR TITLE
feat: loading组件兼容dsl转微信小程序

### DIFF
--- a/src/Loading/index.axml
+++ b/src/Loading/index.axml
@@ -1,13 +1,13 @@
-<import-sjs name="{getLoadingColor, getClass}" from="./index.sjs" />
+<import-sjs name="helper" from="./index.sjs" />
 
 <view 
-  class="ant-loading {{type === 'spin' ? 'ant-loading-spin' :'ant-loading-mini'}} {{getClass(size)}} {{className ? className : ''}}" 
+  class="ant-loading {{type === 'spin' ? 'ant-loading-spin' :'ant-loading-mini'}} {{helper.getClass(size)}} {{className ? className : ''}}" 
   style="{{style}}"
 >
   <block a:if="{{type=== 'spin'}}">
     <view 
       class="ant-loading-spin-icon" 
-      style="background-image: url(data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22100%25%22%20height%3D%22100%25%22%20viewBox%3D%2224%2024%2048%2048%22%3E%3CanimateTransform%20attributeName%3D%22transform%22%20type%3D%22rotate%22%20repeatCount%3D%22indefinite%22%20from%3D%220%22%20to%3D%22360%22%20dur%3D%221400ms%22%3E%3C%2FanimateTransform%3E%3Ccircle%20cx%3D%2248%22%20cy%3D%2248%22%20r%3D%2220%22%20fill%3D%22none%22%20stroke%3D%22%23{{getLoadingColor(color || '#fff')}}%22%20stroke-width%3D%222%22%20transform%3D%22translate%5C\(0%2C0%5C\)%22%3E%3Canimate%20attributeName%3D%22stroke-dasharray%22%20values%3D%221px%2C%20200px%3B100px%2C%20200px%3B100px%2C%20200px%22%20dur%3D%221400ms%22%20repeatCount%3D%22indefinite%22%3E%3C%2Fanimate%3E%3Canimate%20attributeName%3D%22stroke-dashoffset%22%20values%3D%220px%3B-15px%3B-125px%22%20dur%3D%221400ms%22%20repeatCount%3D%22indefinite%22%3E%3C%2Fanimate%3E%3C%2Fcircle%3E%3C%2Fsvg%3E);">
+      style="background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22100%25%22%20height%3D%22100%25%22%20viewBox%3D%2224%2024%2048%2048%22%3E%3CanimateTransform%20attributeName%3D%22transform%22%20type%3D%22rotate%22%20repeatCount%3D%22indefinite%22%20from%3D%220%22%20to%3D%22360%22%20dur%3D%221400ms%22%3E%3C%2FanimateTransform%3E%3Ccircle%20cx%3D%2248%22%20cy%3D%2248%22%20r%3D%2220%22%20fill%3D%22none%22%20stroke%3D%22%23{{helper.getLoadingColor(color || '#fff')}}%22%20stroke-width%3D%222%22%20transform%3D%22translate%5C\(0%2C0%5C\)%22%3E%3Canimate%20attributeName%3D%22stroke-dasharray%22%20values%3D%221px%2C%20200px%3B100px%2C%20200px%3B100px%2C%20200px%22%20dur%3D%221400ms%22%20repeatCount%3D%22indefinite%22%3E%3C%2Fanimate%3E%3Canimate%20attributeName%3D%22stroke-dashoffset%22%20values%3D%220px%3B-15px%3B-125px%22%20dur%3D%221400ms%22%20repeatCount%3D%22indefinite%22%3E%3C%2Fanimate%3E%3C%2Fcircle%3E%3C%2Fsvg%3E');">
     </view>
   </block>
   <block a:else>

--- a/src/Loading/index.sjs
+++ b/src/Loading/index.sjs
@@ -1,13 +1,18 @@
-export function getLoadingColor(color) {
+function getLoadingColor(color) {
   if (typeof color === 'string' && color[0] === '#') {
     return `${color.slice(1)}`;
   }
 }
 
-export function getClass(size) {
+function getClass(size) {
   const list = ['small', 'medium', 'large', 'x-large'];
   if (list.indexOf(size) >=0) {
     return `ant-loading-${size}`;
   }
   return 'ant-loading-medium';
+}
+
+export default {
+  getLoadingColor,
+  getClass,
 }


### PR DESCRIPTION
为方便dsl转换微信小程序做一些语法小调整：
1.微信不支持sjs解构语法，改为普通写法；
2.xml内联style的src()内带上引号，不然微信识别会有问题；