### PR TITLE
fix: fix FormCheckboxGroup、FormRadioGroup label slot

### DIFF
--- a/src/Checkbox/CheckboxGroup/index.axml
+++ b/src/Checkbox/CheckboxGroup/index.axml
@@ -8,7 +8,7 @@
   >
     <view class="ant-checkbox-group-body">
       <block a:if="{{position === 'vertical'}}">
-        <list-item stopPropagation a:for="{{options}}">
+        <list-item a:for="{{options}}">
           <checkbox
             color="{{color}}"
             checked="{{componentUtils.getCheckboxChecked(item, mixin.value)}}"
@@ -18,7 +18,7 @@
             onChange="onChange"
           > 
             <slot name="label" value="{{item}}" index="{{index}}">
-              {{item.label}}
+              <view class="ant-checkbox-group-item-label-default">{{item.label}}</view>
             </slot>  
           </checkbox>
         </list-item>
@@ -34,7 +34,7 @@
           onChange="onChange"
         >
           <slot name="label" value="{{item}}" index="{{index}}">
-            {{item.label}}
+            <view class="ant-checkbox-group-item-label-default">{{item.label}}</view>
           </slot>
         </checkbox>
       </block>

--- a/src/Checkbox/CheckboxGroup/index.less
+++ b/src/Checkbox/CheckboxGroup/index.less
@@ -1,4 +1,4 @@
-@import (reference) "../variable.less";
+@import (reference) '../variable.less';
 
 @checkGroupPrefix: ant-checkbox-group;
 
@@ -41,5 +41,10 @@
   &-body {
     position: relative;
     overflow: hidden;
+    .ant-checkbox-item-content {
+      .ant-checkbox-group-item-label-default:not(:nth-child(1)) {
+        display: none;
+      }
+    }
   }
 }

--- a/src/Form/FormCheckboxGroup/index.axml
+++ b/src/Form/FormCheckboxGroup/index.axml
@@ -13,7 +13,7 @@
 >
   <view>
     <checkbox-group options="{{options}}" value="{{formData.value}}" onChange="onChange" color="{{color}}" position="{{checkboxPosition}}">
-      <slot name="label" slot="label" slot-scope="props" value="{{props.value}}" index="{{props.index}}"/>
+      <slot name="checkboxLabel" slot="label" slot-scope="props" value="{{props.value}}" index="{{props.index}}"/>
     </checkbox-group>
   </view>
   <view slot="extra">

--- a/src/Form/FormRadioGroup/index.axml
+++ b/src/Form/FormRadioGroup/index.axml
@@ -13,7 +13,7 @@
 >
   <view>
     <radio-group options="{{options}}" value="{{formData.value}}" onChange="onChange" color="{{color}}" position="{{radioPosition}}">
-      <slot name="label" slot="label" slot-scope="props" value="{{props.value}}" index="{{props.index}}"/>
+      <slot name="radioLabel" slot="label" slot-scope="props" value="{{props.value}}" index="{{props.index}}"/>
     </radio-group>
   </view>
   <view slot="extra">

--- a/src/Radio/RadioGroup/index.axml
+++ b/src/Radio/RadioGroup/index.axml
@@ -8,7 +8,7 @@
   >
     <view class="ant-radio-group-body">
       <block a:if="{{position === 'vertical'}}">
-        <list-item stopPropagation a:for="{{options}}">
+        <list-item a:for="{{options}}">
           <radio
             checked="{{componentUtils.getChecked(index, options, mixin.value)}}"
             data-index="{{index}}"
@@ -18,7 +18,7 @@
             onChange="onChange"
           > 
             <slot name="label" value="{{item}}" index="{{index}}">
-              {{item.label}}
+              <view class="ant-radio-group-item-label-default">{{item.label}}</view>
             </slot>  
           </radio>
         </list-item>
@@ -34,7 +34,7 @@
           onChange="onChange"
         >
           <slot name="label" value="{{item}}" index="{{index}}">
-            {{item.label}}
+            <view class="ant-radio-group-item-label-default">{{item.label}}</view>
           </slot>
         </radio>
       </block>

--- a/src/Radio/RadioGroup/index.less
+++ b/src/Radio/RadioGroup/index.less
@@ -41,5 +41,10 @@
   &-body {
     position: relative;
     overflow: hidden;
+    .ant-radio-item-content {
+      .ant-radio-group-item-label-default:not(:nth-child(1)) {
+        display: none;
+      }
+    }
   }
 }


### PR DESCRIPTION
appx2下slot传递两层会导致自定义slot和slot 默认内容渲染两次，此处使用css判断的方式隐藏掉自定义slot时默认内容节点。
用于FormCheckboxGroup、FormRadioGroup label slot