### PR TITLE
fix: form

### DIFF
--- a/src/Form/form.ts
+++ b/src/Form/form.ts
@@ -244,12 +244,21 @@ class Field extends EventEmitter{
     }
     const validator = this.validator;
     try {
-      this.setValidatorStatus({
-        status: 'validating',
-        errors: []
+      let needUpdateStatus = true;
+      Promise.resolve().then(() => {
+        Promise.resolve().then(() => {
+          if (needUpdateStatus) {
+            this.setValidatorStatus({
+              status: 'validating',
+              errors: [],
+            });
+          }
+        });
       });
       await this.validator.validate({
         [this.name]: value,
+      }, () => {
+        needUpdateStatus = false;
       });
       if (validator !== this.validator) {
         return;


### PR DESCRIPTION
- [x] 修改在真机可能会有抖动的情况。

抖动是由于会有一个 validating 的状态，这个状态是用于异步校验的loading，比如需要通过后台来校验一个input是否合法。但是对于一般的校验，这个状态会让页面抖动下。这里通过判断 Promise 来解决这个问题。这里没有用 setTimeout 是由于 IOS 下小程序里Promise其实不是微任务了，无法使用 setTimeout Promise的关系来做判断。