### PR TITLE
fix: DatePicker

### DIFF
--- a/src/DatePicker/RangePicker/index.ts
+++ b/src/DatePicker/RangePicker/index.ts
@@ -122,8 +122,8 @@ Component({
           const { max } = currentProps;
           currentStartDate = new Date();
           if (
-            (min && currentStartDate < min) ||
-            (max && currentStartDate > max) ||
+            (min && dayjs(currentStartDate).isBefore(min, precision)) ||
+            (max && dayjs(currentStartDate).isAfter(max, precision)) ||
             (currentEndDateByCValue &&
               currentStartDate > currentEndDateByCValue)
           ) {

--- a/src/DatePicker/index.ts
+++ b/src/DatePicker/index.ts
@@ -65,8 +65,8 @@ Component({
       } else {
         const now = new Date();
         if (
-          !(min && dayjs(now).isBefore(dayjs(min as any))) &&
-          !(max && dayjs(now).isAfter(dayjs(max as any)))
+          !(min && dayjs(now).isBefore(dayjs(min as any), precision)) &&
+          !(max && dayjs(now).isAfter(dayjs(max as any), precision))
         ) {
           return getValueByDate(now, precision);
         } else {


### PR DESCRIPTION
修复不传值时打开时间选择默认定位项边界问题，默认定位当前时间，当前时间不在范围内定位最小值