### PR TITLE
fix: 修复 form 表单 createForm Api 误写问题

### DIFF
--- a/src/Form/index.md
+++ b/src/Form/index.md
@@ -283,14 +283,14 @@ type ValidatorStatus = {
 ### FormImageUpload
 同 ImageUpload
 
-### createform
+### createForm
 
-createform是一个mixin，在自定义表单项使用
+createForm是一个mixin，在自定义表单项使用
 ```js
-import { createform } from 'antd-mini/es/Form/form';
+import { createForm } from 'antd-mini/es/Form/form';
 
 Component({
-  mixins: [createform()],
+  mixins: [createForm()],
   methods: {
     onChange(value) {
       this.emit('onChange', value);
@@ -299,7 +299,7 @@ Component({
 })
 ```
 
-createform会在Component加上
+createForm会在Component加上
 - data
 ```js
 {


### PR DESCRIPTION
createform 并不是 'antd-mini/es/Form/form' 导出的方法。
![image](https://github.com/ant-design/ant-design-mini/assets/77064828/7907ab92-011c-44d0-8838-e6b82e0070c4)
