### PR TITLE
fix: should not use element selector

### DIFF
--- a/src/Empty/index.axml
+++ b/src/Empty/index.axml
@@ -2,7 +2,7 @@
   <view class="ant-empty">
     <view class="ant-empty-image">
       <slot name="image">
-        <image src="{{image || 'https://gw.alipayobjects.com/mdn/rms_226d75/afts/img/A*0AaRRrYlVDkAAAAAAAAAAAAAARQnAQ'}}" />
+        <image class="ant-empty-image-element" src="{{image || 'https://gw.alipayobjects.com/mdn/rms_226d75/afts/img/A*0AaRRrYlVDkAAAAAAAAAAAAAARQnAQ'}}" />
       </slot>
     </view>
     <view class="ant-empty-text">

--- a/src/Empty/index.less
+++ b/src/Empty/index.less
@@ -10,7 +10,7 @@
     display: flex;
     justify-content: center;
 
-    image {
+    &-image-element {
       width: 200 * @rpx;
       height: 170 * @rpx;
     }

--- a/src/Empty/index.less
+++ b/src/Empty/index.less
@@ -10,7 +10,7 @@
     display: flex;
     justify-content: center;
 
-    &-image-element {
+    image {
       width: 200 * @rpx;
       height: 170 * @rpx;
     }

--- a/src/Empty/index.less
+++ b/src/Empty/index.less
@@ -1,4 +1,4 @@
-@import (reference) "./variable.less";
+@import (reference) './variable.less';
 
 @emptyPrefix: ant-empty;
 
@@ -9,7 +9,8 @@
   &-image {
     display: flex;
     justify-content: center;
-    image {
+
+    &-image-element {
       width: 200 * @rpx;
       height: 170 * @rpx;
     }

--- a/src/Empty/index.less
+++ b/src/Empty/index.less
@@ -10,7 +10,7 @@
     display: flex;
     justify-content: center;
 
-    &-image-element {
+    &-element {
       width: 200 * @rpx;
       height: 170 * @rpx;
     }

--- a/src/Empty/index.ts
+++ b/src/Empty/index.ts
@@ -2,4 +2,4 @@ import { EmptyDefaultProps } from './props';
 
 Component({
   props: EmptyDefaultProps,
-})
+});

--- a/src/_util/__tests__/compareVersion.spec.ts
+++ b/src/_util/__tests__/compareVersion.spec.ts
@@ -1,0 +1,19 @@
+import { compareVersion } from "../compareVersion";
+
+
+
+
+
+
+it('test compareVersion', () => {
+
+  expect(compareVersion('1.0.0', "2.9.9")).toBe(-1)
+  expect(compareVersion('1.0.0', "1.0.1")).toBe(-1)
+  expect(compareVersion('1.0.0', "1.1.0")).toBe(-1)
+  expect(compareVersion('1.0.0', "1.1")).toBe(-1)
+
+  expect(compareVersion('2.9.9', "1.0.0")).toBe(1)
+
+
+  expect(compareVersion('1.0.0', "1.0.0")).toBe(0)
+})

--- a/src/_util/__tests__/compareVersion.spec.ts
+++ b/src/_util/__tests__/compareVersion.spec.ts
@@ -1,19 +1,13 @@
-import { compareVersion } from "../compareVersion";
-
-
-
-
-
+import { expect, it } from 'vitest';
+import { compareVersion } from '../compareVersion';
 
 it('test compareVersion', () => {
+  expect(compareVersion('1.0.0', '2.9.9')).toBe(-1);
+  expect(compareVersion('1.0.0', '1.0.1')).toBe(-1);
+  expect(compareVersion('1.0.0', '1.1.0')).toBe(-1);
+  expect(compareVersion('1.0.0', '1.1')).toBe(-1);
 
-  expect(compareVersion('1.0.0', "2.9.9")).toBe(-1)
-  expect(compareVersion('1.0.0', "1.0.1")).toBe(-1)
-  expect(compareVersion('1.0.0', "1.1.0")).toBe(-1)
-  expect(compareVersion('1.0.0', "1.1")).toBe(-1)
+  expect(compareVersion('2.9.9', '1.0.0')).toBe(1);
 
-  expect(compareVersion('2.9.9', "1.0.0")).toBe(1)
-
-
-  expect(compareVersion('1.0.0', "1.0.0")).toBe(0)
-})
+  expect(compareVersion('1.0.0', '1.0.0')).toBe(0);
+});

--- a/src/_util/compareVersion.ts
+++ b/src/_util/compareVersion.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 export function compareVersion(v1: string, v2: string): number {
   if (v1 === v2) return 0;
   const v1Arr = v1.split('.');
@@ -11,7 +10,6 @@ export function compareVersion(v1: string, v2: string): number {
     } else if (!v1Arr[i] || !v2Arr[i]) {
       return v1Arr.length > v2Arr.length ? 1 : -1;
     } else {
-      // eslint-disable-next-line no-nested-ternary
       return Number(v1Arr[i]) === Number(v2Arr[i])
         ? 0
         : Number(v1Arr[i]) > Number(v2Arr[i])

--- a/src/_util/console.ts
+++ b/src/_util/console.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-shadow
 export enum EComponents {
   Alphabet = 'Alphabet',
   AmountInput = 'AmountInput',


### PR DESCRIPTION
修复 https://github.com/ant-design/ant-design-mini/issues/807

不能使用 `image` selector