### PR TITLE
fix: raise the layer of picker mask to a compositing layer

### DIFF
--- a/src/Picker/index.less
+++ b/src/Picker/index.less
@@ -59,6 +59,7 @@
           fade(@COLOR_CARD, 60)
         ),
         linear-gradient(to top, fade(@COLOR_CARD, 95), fade(@COLOR_CARD, 60));
+      will-change: transform;
     }
   }
   &-value {


### PR DESCRIPTION
Raise the layer of picker mask to accelerate the rendering of the mask on IOS