### PR TITLE
fix: Avatar/不再消失

### DIFF
--- a/compiled/alipay/src/Avatar/index.axml
+++ b/compiled/alipay/src/Avatar/index.axml
@@ -6,7 +6,6 @@
   class="ant-avatar {{ className ? className : '' }}"
   style="{{ style }}">
   <image
-    a:if="{{ src !== null }}"
     class="ant-avatar-image {{ utils.getClass(size) }}"
     src="{{ src || utils.defaultSrc }}" />
 </view>

--- a/compiled/alipay/src/Avatar/props.ts
+++ b/compiled/alipay/src/Avatar/props.ts
@@ -12,10 +12,10 @@ export interface IAvatarProps extends IBaseProps {
   /**
    * @description 头像地址，默认为灰色的内置图片
    */
-  src: string | null;
+  src: string;
 }
 
 export const AvatarDefaultProps: Partial<IAvatarProps> = {
   size: 'medium',
-  src: null,
+  src: '',
 };

--- a/compiled/wechat/src/Avatar/index.wxml
+++ b/compiled/wechat/src/Avatar/index.wxml
@@ -6,7 +6,6 @@
   class="ant-avatar {{ className ? className : '' }}"
   style="{{ style }}">
   <image
-    wx:if="{{ src !== null }}"
     class="ant-avatar-image {{ utils.getClass(size) }}"
     src="{{ src || utils.defaultSrc }}" />
 </view>

--- a/compiled/wechat/src/Avatar/props.js
+++ b/compiled/wechat/src/Avatar/props.js
@@ -1,4 +1,4 @@
 export var AvatarDefaultProps = {
     size: 'medium',
-    src: null,
+    src: '',
 };

--- a/src/Avatar/index.axml.tsx
+++ b/src/Avatar/index.axml.tsx
@@ -4,7 +4,7 @@ import { IAvatarProps } from './props';
 
 export default ({ className, style, size, src }: TSXMLProps<IAvatarProps>) => (
   <View class={`ant-avatar ${className ? className : ''}`} style={style}>
-    {(src !== null) && (
+    {(
       <Image class={`ant-avatar-image ${utils.getClass(size)}`} src={src || utils.defaultSrc} />
     )}
   </View>

--- a/src/Avatar/props.ts
+++ b/src/Avatar/props.ts
@@ -12,10 +12,10 @@ export interface IAvatarProps extends IBaseProps {
   /**
    * @description 头像地址，默认为灰色的内置图片
    */
-  src: string | null;
+  src: string;
 }
 
 export const AvatarDefaultProps: Partial<IAvatarProps> = {
   size: 'medium',
-  src: null,
+  src: '',
 };


### PR DESCRIPTION
原行为：
- src 外部传入非 `undefined` 值，不显示
- src 不传入，显示默认占位

改坏之后：
- src 不传入，默认 Avatar 不显示（微信）

新行为：
- src 外部传入任意值（包括 Falsy），均显示
- src 不传入，显示默认占位