### PR TITLE
fix: 修改 updateScroll 调用时机

### DIFF
--- a/compiled/alipay/src/Tabs/index.ts
+++ b/compiled/alipay/src/Tabs/index.ts
@@ -1,5 +1,10 @@
-import { useEffect, useState } from 'functional-mini/compat';
-import { useEvent, useReady, useRef } from 'functional-mini/component';
+import { useState } from 'functional-mini/compat';
+import {
+  useDidMount,
+  useEvent,
+  useReady,
+  useRef,
+} from 'functional-mini/component';
 import '../_util/assert-component2';
 import { mountComponent } from '../_util/component';
 import { useComponentEvent } from '../_util/hooks/useComponentEvent';
@@ -66,6 +71,9 @@ const Tabs = (props: ITabsProps) => {
         (id) => `#ant-tabs-bar-item${id}-${current}`
       ),
     ]);
+    if (!view || !item) {
+      return;
+    }
 
     if (props.direction === 'vertical') {
       let scrollTop = scrollRef.current.scrollTop || 0;
@@ -144,7 +152,7 @@ const Tabs = (props: ITabsProps) => {
     triggerEvent('change', index, e);
   });
 
-  useEffect(() => {
+  useDidMount(() => {
     updateScroll();
   }, []);
 

--- a/compiled/wechat/src/Tabs/index.js
+++ b/compiled/wechat/src/Tabs/index.js
@@ -46,7 +46,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 import { useState } from 'functional-mini/compat';
-import { useEvent, useReady, useRef } from 'functional-mini/component';
+import { useEvent, useReady, useRef, } from 'functional-mini/component';
 import '../_util/assert-component2';
 import { mountComponent } from '../_util/component';
 import { useComponentEvent } from '../_util/hooks/useComponentEvent';
@@ -106,6 +106,9 @@ var Tabs = function (props) {
                         ])];
                 case 1:
                     _a = _b.sent(), view = _a[0], item = _a[1];
+                    if (!view || !item) {
+                        return [2 /*return*/];
+                    }
                     if (props.direction === 'vertical') {
                         scrollTop = scrollRef.current.scrollTop || 0;
                         needScroll_1 = false;

--- a/src/Tabs/index.ts
+++ b/src/Tabs/index.ts
@@ -1,5 +1,10 @@
-import { useEffect, useState } from 'functional-mini/compat';
-import { useEvent, useReady, useRef } from 'functional-mini/component';
+import { useState } from 'functional-mini/compat';
+import {
+  useDidMount,
+  useEvent,
+  useReady,
+  useRef,
+} from 'functional-mini/component';
 import '../_util/assert-component2';
 import { mountComponent } from '../_util/component';
 import { useComponentEvent } from '../_util/hooks/useComponentEvent';
@@ -66,6 +71,9 @@ const Tabs = (props: ITabsProps) => {
         (id) => `#ant-tabs-bar-item${id}-${current}`
       ),
     ]);
+    if (!view || !item) {
+      return;
+    }
 
     if (props.direction === 'vertical') {
       let scrollTop = scrollRef.current.scrollTop || 0;
@@ -145,7 +153,7 @@ const Tabs = (props: ITabsProps) => {
   });
 
   /// #if ALIPAY
-  useEffect(() => {
+  useDidMount(() => {
     updateScroll();
   }, []);
   /// #endif


### PR DESCRIPTION
在 useEffect ( onInit ) 生命周期调用 updateScroll 的话，有时候会出现元素找不到的情况。