### PR TITLE
feat: 优化calendar组件选中交互，日期滚动到可视区域内

### DIFF
--- a/compiled/alipay/demo/pages/Calendar/index.axml
+++ b/compiled/alipay/demo/pages/Calendar/index.axml
@@ -16,7 +16,8 @@
     style="height: 1000rpx">
     <ant-calendar
       selectionMode="single"
-      defaultValue="{{ demo2.defaultValue }}" />
+      defaultValue="{{ demo2.defaultValue }}"
+      changedScrollIntoView />
   </view>
 </collapse-container>
 

--- a/compiled/alipay/demo/pages/Calendar/index.js
+++ b/compiled/alipay/demo/pages/Calendar/index.js
@@ -46,7 +46,7 @@ Page({
             visible: true,
         },
         demo2: {
-            defaultValue: Date.now(),
+            defaultValue: dayjs().add(1, 'M').toDate().getTime(),
             visible: true,
         },
         demo3: {

--- a/compiled/alipay/src/Calendar/index.axml
+++ b/compiled/alipay/src/Calendar/index.axml
@@ -37,6 +37,9 @@
     data-elementsize="{{ elementSize }}"
     data-monthlist="{{ monthList }}"
     onScroll="{{ scroll.handleScroll }}"
+    scroll-into-view="{{ scrollIntoViewId }}"
+    scroll-with-animation
+    scroll-animation-duration="{{ 300 }}"
     ref="handleRef">
     <block
       a:for="{{ monthList }}"
@@ -56,6 +59,7 @@
             <block>
               <view
                 class="{{ helper.getClassName(item, index) }}"
+                id="id_{{ item.time }}"
                 data-time="{{ item }}"
                 onTap="clickCell">
                 <view class="ant-calendar-cell-container">

--- a/compiled/alipay/src/Calendar/index.md
+++ b/compiled/alipay/src/Calendar/index.md
@@ -21,16 +21,18 @@ toc: 'content'
 
 以下为日历组件的属性及描述：
 
-| 属性          | 说明                                            | 类型                                                        | 默认值      |
-| ------------- | ---------------------------------------------- | ----------------------------------------------------------- | ----------- |
-| defaultValue  | 初始值                                          | CalendarValue                                               | 无          |
-| value         | 日历选择的日期，传入后即为受控模式                   | CalendarValue                                               | 无          |
-| selectionMode | 设置选择模式，单选或者连续区间，默认为 `range`       | `single` \| `range`                                         | `range`     |
-| monthRange    | 月份范围，默认为最近 3 个月                       | `[number, number]`                                          | 最近 3 个月 |
-| weekStartsOn  | 星期栏，以周几作为第一天显示。默认为 `Sunday`       | `Sunday` \| `Monday`                                        | `Sunday`    |
-| onChange      | 日期变化回调                                    | (date: CalendarValue) => void                               | 无          |
-| onFormatter   | 用于设置单元格的自定义数据                        | (cell: CellState, currentValue: CalendarValue) => CellState  | 无          |
-| localeText    | 国际化文案                                      | Partial`<LocaleText>`                                       | 无          |
+| 属性                  | 说明                                           | 类型                                                        | 默认值      |
+| --------------------- | ---------------------------------------------- | ----------------------------------------------------------- | ----------- |
+| defaultValue          | 初始值                                         | CalendarValue                                               | 无          |
+| value                 | 日历选择的日期，传入后即为受控模式             | CalendarValue                                               | 无          |
+| selectionMode         | 设置选择模式，单选或者连续区间，默认为 `range` | `single` \| `range`                                         | `range`     |
+| monthRange            | 月份范围，默认为最近 3 个月                    | `[number, number]`                                          | 最近 3 个月 |
+| weekStartsOn          | 星期栏，以周几作为第一天显示。默认为 `Sunday`  | `Sunday` \| `Monday`                                        | `Sunday`    |
+| onChange              | 日期变化回调                                   | (date: CalendarValue) => void                               | 无          |
+| onFormatter           | 用于设置单元格的自定义数据                     | (cell: CellState, currentValue: CalendarValue) => CellState | 无          |
+| localeText            | 国际化文案                                     | Partial`<LocaleText>`                                       | 无          |
+| changedScrollIntoView | 选中值改变后是否滚动视图                       | boolean                                                     | 无          |
+
 ### 类型
 
 **CalendarValue** : 日历的值类型，为数字或数字元组 `number | [number,number]`，表示单选或连续日期区间。单位为毫秒的时间戳。

--- a/compiled/alipay/src/Calendar/index.ts
+++ b/compiled/alipay/src/Calendar/index.ts
@@ -188,11 +188,19 @@ const Calendar = (props: ICalendarProps) => {
     }
   });
 
+  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
+  const scrollIntoViewId = `id_${dayjs(Array.isArray(value) ? value[0] : value)
+    .startOf('d')
+    .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
+    .toDate()
+    .getTime()}`;
+
   return {
     elementSize,
     markItems,
     monthList,
     headerState,
+    scrollIntoViewId,
   };
 };
 

--- a/compiled/alipay/src/Calendar/index.ts
+++ b/compiled/alipay/src/Calendar/index.ts
@@ -4,6 +4,7 @@ import {
   useEvent,
   useReady,
   useState,
+  useEffect,
 } from 'functional-mini/component';
 import { mountComponent } from '../_util/component';
 import { useComponentEvent } from '../_util/hooks/useComponentEvent';
@@ -74,9 +75,6 @@ const Calendar = (props: ICalendarProps) => {
   function updateValue(newValue: CalendarValue) {
     const isControl = hasValue(props.value);
     triggerEvent('change', newValue);
-    // 滚动到已选的位置
-    props.changedScrollIntoView &&
-      setScrollIntoViewId(getScrollIntoViewId(newValue));
     if (!isControl) {
       setValue(newValue);
     }
@@ -194,11 +192,22 @@ const Calendar = (props: ICalendarProps) => {
       });
   }
 
+  useEffect(() => {
+    // 滚动到已选的位置
+    props.changedScrollIntoView &&
+      setScrollIntoViewId(getScrollIntoViewId(value));
+  }, [value]);
+
   useReady(() => {
     measurement();
-    // 初始化默认值时，滚动到默认值位置
-    props.defaultValue &&
-      setScrollIntoViewId(getScrollIntoViewId(props.defaultValue));
+    // 初始化默认值时，滚动到选中位置
+    const isControl = hasValue(props.value);
+    if (isControl) {
+      setScrollIntoViewId(getScrollIntoViewId(props.value));
+    } else {
+      props.defaultValue &&
+        setScrollIntoViewId(getScrollIntoViewId(props.defaultValue));
+    }
   }, []);
 
   useEvent('measurement', () => {

--- a/compiled/alipay/src/Calendar/index.ts
+++ b/compiled/alipay/src/Calendar/index.ts
@@ -37,6 +37,19 @@ function getBoundingClientRect(instance: any, selector: string) {
   });
 }
 
+// 获取滚动视图的元素id
+function getScrollIntoViewId(value) {
+  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
+  return `id_${
+    value &&
+    dayjs(Array.isArray(value) ? value[0] : value)
+      .startOf('d')
+      .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
+      .toDate()
+      .getTime()
+  }`;
+}
+
 const Calendar = (props: ICalendarProps) => {
   const localeText = Object.assign({}, defaultLocaleText, props.localeText);
 
@@ -51,6 +64,8 @@ const Calendar = (props: ICalendarProps) => {
     value: props.value,
   });
 
+  const [scrollIntoViewId, setScrollIntoViewId] = useState<string>('');
+
   const selectionModeFromValue = getSelectionModeFromValue(value);
   const selectionMode =
     props.selectionMode ?? selectionModeFromValue ?? 'range';
@@ -59,6 +74,9 @@ const Calendar = (props: ICalendarProps) => {
   function updateValue(newValue: CalendarValue) {
     const isControl = hasValue(props.value);
     triggerEvent('change', newValue);
+    // 滚动到已选的位置
+    props.changedScrollIntoView &&
+      setScrollIntoViewId(getScrollIntoViewId(newValue));
     if (!isControl) {
       setValue(newValue);
     }
@@ -178,6 +196,9 @@ const Calendar = (props: ICalendarProps) => {
 
   useReady(() => {
     measurement();
+    // 初始化默认值时，滚动到默认值位置
+    props.defaultValue &&
+      setScrollIntoViewId(getScrollIntoViewId(props.defaultValue));
   }, []);
 
   useEvent('measurement', () => {
@@ -187,13 +208,6 @@ const Calendar = (props: ICalendarProps) => {
       measurement();
     }
   });
-
-  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
-  const scrollIntoViewId = `id_${dayjs(Array.isArray(value) ? value[0] : value)
-    .startOf('d')
-    .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
-    .toDate()
-    .getTime()}`;
 
   return {
     elementSize,

--- a/compiled/alipay/src/Calendar/index.ts
+++ b/compiled/alipay/src/Calendar/index.ts
@@ -20,6 +20,7 @@ import {
   getMonthListFromRange,
   getSelectionModeFromValue,
   renderCells,
+  getScrollIntoViewId,
 } from './utils';
 
 function getBoundingClientRect(instance: any, selector: string) {
@@ -36,19 +37,6 @@ function getBoundingClientRect(instance: any, selector: string) {
         }
       });
   });
-}
-
-// 获取滚动视图的元素id
-function getScrollIntoViewId(value) {
-  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
-  return `id_${
-    value &&
-    dayjs(Array.isArray(value) ? value[0] : value)
-      .startOf('d')
-      .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
-      .toDate()
-      .getTime()
-  }`;
 }
 
 const Calendar = (props: ICalendarProps) => {

--- a/compiled/alipay/src/Calendar/props.ts
+++ b/compiled/alipay/src/Calendar/props.ts
@@ -115,6 +115,10 @@ export interface ICalendarProps extends IBaseProps {
    */
   localeText?: Partial<LocaleText>;
   /**
+   * 选中值改变后是否滚动视图
+   */
+  changedScrollIntoView?: boolean;
+  /**
    * 日期变化回调
    */
   onChange?: (date: CalendarValue) => void;

--- a/compiled/alipay/src/Calendar/props.ts
+++ b/compiled/alipay/src/Calendar/props.ts
@@ -115,7 +115,7 @@ export interface ICalendarProps extends IBaseProps {
    */
   localeText?: Partial<LocaleText>;
   /**
-   * 选中值改变后是否滚动视图
+   * 选中值改变后滚动视图
    */
   changedScrollIntoView?: boolean;
   /**

--- a/compiled/alipay/src/Calendar/utils.ts
+++ b/compiled/alipay/src/Calendar/utils.ts
@@ -161,3 +161,16 @@ export function getSelectionModeFromValue(
   }
   return null;
 }
+
+// 获取滚动视图的元素id
+export function getScrollIntoViewId(value: CalendarValue) {
+  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
+  return `id_${
+    value &&
+    dayjs(Array.isArray(value) ? value[0] : value)
+      .startOf('d')
+      .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
+      .toDate()
+      .getTime()
+  }`;
+}

--- a/compiled/wechat/demo/pages/Calendar/index.js
+++ b/compiled/wechat/demo/pages/Calendar/index.js
@@ -46,7 +46,7 @@ Page({
             visible: true,
         },
         demo2: {
-            defaultValue: Date.now(),
+            defaultValue: dayjs().add(1, 'M').toDate().getTime(),
             visible: true,
         },
         demo3: {

--- a/compiled/wechat/demo/pages/Calendar/index.wxml
+++ b/compiled/wechat/demo/pages/Calendar/index.wxml
@@ -16,7 +16,8 @@
     style="height: 1000rpx">
     <ant-calendar
       selectionMode="single"
-      defaultValue="{{ demo2.defaultValue }}" />
+      defaultValue="{{ demo2.defaultValue }}"
+      changedScrollIntoView />
   </view>
 </collapse-container>
 

--- a/compiled/wechat/src/Calendar/index.js
+++ b/compiled/wechat/src/Calendar/index.js
@@ -41,6 +41,16 @@ function getBoundingClientRect(instance, selector) {
         });
     });
 }
+// 获取滚动视图的元素id
+function getScrollIntoViewId(value) {
+    // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
+    return "id_".concat(value &&
+        dayjs(Array.isArray(value) ? value[0] : value)
+            .startOf('d')
+            .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
+            .toDate()
+            .getTime());
+}
 var Calendar = function (props) {
     var _a, _b;
     var localeText = Object.assign({}, defaultLocaleText, props.localeText);
@@ -54,12 +64,16 @@ var Calendar = function (props) {
     var _c = useMergedState(props.defaultValue, {
         value: props.value,
     }), value = _c[0], setValue = _c[1];
+    var _d = useState(''), scrollIntoViewId = _d[0], setScrollIntoViewId = _d[1];
     var selectionModeFromValue = getSelectionModeFromValue(value);
     var selectionMode = (_b = (_a = props.selectionMode) !== null && _a !== void 0 ? _a : selectionModeFromValue) !== null && _b !== void 0 ? _b : 'range';
     var triggerEvent = useComponentEvent(props).triggerEvent;
     function updateValue(newValue) {
         var isControl = hasValue(props.value);
         triggerEvent('change', newValue);
+        // 滚动到已选的位置
+        props.changedScrollIntoView &&
+            setScrollIntoViewId(getScrollIntoViewId(newValue));
         if (!isControl) {
             setValue(newValue);
         }
@@ -125,11 +139,11 @@ var Calendar = function (props) {
             cells: cells,
         };
     });
-    var _d = useState(0), headerState = _d[0], setHeaderState = _d[1];
+    var _e = useState(0), headerState = _e[0], setHeaderState = _e[1];
     useEvent('setCurrentMonth', function (e) {
         setHeaderState(e.month);
     });
-    var _e = useState(null), elementSize = _e[0], setElementSize = _e[1];
+    var _f = useState(null), elementSize = _f[0], setElementSize = _f[1];
     var componentInstance = useComponent();
     function measurement() {
         Promise.all([
@@ -156,6 +170,9 @@ var Calendar = function (props) {
     }
     useReady(function () {
         measurement();
+        // 初始化默认值时，滚动到默认值位置
+        props.defaultValue &&
+            setScrollIntoViewId(getScrollIntoViewId(props.defaultValue));
     }, []);
     useEvent('measurement', function () {
         // 组件如果内嵌在 slot 里, 一定会被渲染出来, 但是此时 cellHight 为 0
@@ -164,12 +181,6 @@ var Calendar = function (props) {
             measurement();
         }
     });
-    // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
-    var scrollIntoViewId = "id_".concat(dayjs(Array.isArray(value) ? value[0] : value)
-        .startOf('d')
-        .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
-        .toDate()
-        .getTime());
     return {
         elementSize: elementSize,
         markItems: markItems,

--- a/compiled/wechat/src/Calendar/index.js
+++ b/compiled/wechat/src/Calendar/index.js
@@ -19,7 +19,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || Array.prototype.slice.call(from));
 };
 import dayjs from 'dayjs';
-import { useComponent, useEvent, useReady, useState, } from 'functional-mini/component';
+import { useComponent, useEvent, useReady, useState, useEffect, } from 'functional-mini/component';
 import { mountComponent } from '../_util/component';
 import { useComponentEvent } from '../_util/hooks/useComponentEvent';
 import { hasValue, useMergedState } from '../_util/hooks/useMergedState';
@@ -71,9 +71,6 @@ var Calendar = function (props) {
     function updateValue(newValue) {
         var isControl = hasValue(props.value);
         triggerEvent('change', newValue);
-        // 滚动到已选的位置
-        props.changedScrollIntoView &&
-            setScrollIntoViewId(getScrollIntoViewId(newValue));
         if (!isControl) {
             setValue(newValue);
         }
@@ -168,11 +165,22 @@ var Calendar = function (props) {
             setElementSize(null);
         });
     }
+    useEffect(function () {
+        // 滚动到已选的位置
+        props.changedScrollIntoView &&
+            setScrollIntoViewId(getScrollIntoViewId(value));
+    }, [value]);
     useReady(function () {
         measurement();
-        // 初始化默认值时，滚动到默认值位置
-        props.defaultValue &&
-            setScrollIntoViewId(getScrollIntoViewId(props.defaultValue));
+        // 初始化默认值时，滚动到选中位置
+        var isControl = hasValue(props.value);
+        if (isControl) {
+            setScrollIntoViewId(getScrollIntoViewId(props.value));
+        }
+        else {
+            props.defaultValue &&
+                setScrollIntoViewId(getScrollIntoViewId(props.defaultValue));
+        }
     }, []);
     useEvent('measurement', function () {
         // 组件如果内嵌在 slot 里, 一定会被渲染出来, 但是此时 cellHight 为 0

--- a/compiled/wechat/src/Calendar/index.js
+++ b/compiled/wechat/src/Calendar/index.js
@@ -164,11 +164,18 @@ var Calendar = function (props) {
             measurement();
         }
     });
+    // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
+    var scrollIntoViewId = "id_".concat(dayjs(Array.isArray(value) ? value[0] : value)
+        .startOf('d')
+        .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
+        .toDate()
+        .getTime());
     return {
         elementSize: elementSize,
         markItems: markItems,
         monthList: monthList,
         headerState: headerState,
+        scrollIntoViewId: scrollIntoViewId,
     };
 };
 mountComponent(Calendar, {

--- a/compiled/wechat/src/Calendar/index.js
+++ b/compiled/wechat/src/Calendar/index.js
@@ -24,7 +24,7 @@ import { mountComponent } from '../_util/component';
 import { useComponentEvent } from '../_util/hooks/useComponentEvent';
 import { hasValue, useMergedState } from '../_util/hooks/useMergedState';
 import { defaultLocaleText, } from './props';
-import { defaultMonthRange, getMonthListFromRange, getSelectionModeFromValue, renderCells, } from './utils';
+import { defaultMonthRange, getMonthListFromRange, getSelectionModeFromValue, renderCells, getScrollIntoViewId, } from './utils';
 function getBoundingClientRect(instance, selector) {
     return new Promise(function (resolve, reject) {
         instance
@@ -40,16 +40,6 @@ function getBoundingClientRect(instance, selector) {
             }
         });
     });
-}
-// 获取滚动视图的元素id
-function getScrollIntoViewId(value) {
-    // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
-    return "id_".concat(value &&
-        dayjs(Array.isArray(value) ? value[0] : value)
-            .startOf('d')
-            .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
-            .toDate()
-            .getTime());
 }
 var Calendar = function (props) {
     var _a, _b;

--- a/compiled/wechat/src/Calendar/index.md
+++ b/compiled/wechat/src/Calendar/index.md
@@ -21,16 +21,18 @@ toc: 'content'
 
 以下为日历组件的属性及描述：
 
-| 属性          | 说明                                            | 类型                                                        | 默认值      |
-| ------------- | ---------------------------------------------- | ----------------------------------------------------------- | ----------- |
-| defaultValue  | 初始值                                          | CalendarValue                                               | 无          |
-| value         | 日历选择的日期，传入后即为受控模式                   | CalendarValue                                               | 无          |
-| selectionMode | 设置选择模式，单选或者连续区间，默认为 `range`       | `single` \| `range`                                         | `range`     |
-| monthRange    | 月份范围，默认为最近 3 个月                       | `[number, number]`                                          | 最近 3 个月 |
-| weekStartsOn  | 星期栏，以周几作为第一天显示。默认为 `Sunday`       | `Sunday` \| `Monday`                                        | `Sunday`    |
-| onChange      | 日期变化回调                                    | (date: CalendarValue) => void                               | 无          |
-| onFormatter   | 用于设置单元格的自定义数据                        | (cell: CellState, currentValue: CalendarValue) => CellState  | 无          |
-| localeText    | 国际化文案                                      | Partial`<LocaleText>`                                       | 无          |
+| 属性                  | 说明                                           | 类型                                                        | 默认值      |
+| --------------------- | ---------------------------------------------- | ----------------------------------------------------------- | ----------- |
+| defaultValue          | 初始值                                         | CalendarValue                                               | 无          |
+| value                 | 日历选择的日期，传入后即为受控模式             | CalendarValue                                               | 无          |
+| selectionMode         | 设置选择模式，单选或者连续区间，默认为 `range` | `single` \| `range`                                         | `range`     |
+| monthRange            | 月份范围，默认为最近 3 个月                    | `[number, number]`                                          | 最近 3 个月 |
+| weekStartsOn          | 星期栏，以周几作为第一天显示。默认为 `Sunday`  | `Sunday` \| `Monday`                                        | `Sunday`    |
+| onChange              | 日期变化回调                                   | (date: CalendarValue) => void                               | 无          |
+| onFormatter           | 用于设置单元格的自定义数据                     | (cell: CellState, currentValue: CalendarValue) => CellState | 无          |
+| localeText            | 国际化文案                                     | Partial`<LocaleText>`                                       | 无          |
+| changedScrollIntoView | 选中值改变后是否滚动视图                       | boolean                                                     | 无          |
+
 ### 类型
 
 **CalendarValue** : 日历的值类型，为数字或数字元组 `number | [number,number]`，表示单选或连续日期区间。单位为毫秒的时间戳。

--- a/compiled/wechat/src/Calendar/index.wxml
+++ b/compiled/wechat/src/Calendar/index.wxml
@@ -33,6 +33,9 @@
     data-elementsize="{{ elementSize }}"
     data-monthlist="{{ monthList }}"
     bind:scroll="{{ scroll.handleScroll }}"
+    scroll-into-view="{{ scrollIntoViewId }}"
+    scroll-with-animation
+    scroll-animation-duration="{{ 300 }}"
     bind:ref="handleRef">
     <block
       wx:for="{{ monthList }}"
@@ -50,6 +53,7 @@
             <block>
               <view
                 class="{{ helper.getClassName(item, index) }}"
+                id="id_{{ item.time }}"
                 data-time="{{ item }}"
                 bind:tap="clickCell">
                 <view class="ant-calendar-cell-container">

--- a/compiled/wechat/src/Calendar/utils.js
+++ b/compiled/wechat/src/Calendar/utils.js
@@ -138,3 +138,13 @@ export function getSelectionModeFromValue(value) {
     }
     return null;
 }
+// 获取滚动视图的元素id
+export function getScrollIntoViewId(value) {
+    // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
+    return "id_".concat(value &&
+        dayjs(Array.isArray(value) ? value[0] : value)
+            .startOf('d')
+            .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
+            .toDate()
+            .getTime());
+}

--- a/demo/pages/Calendar/index.axml.tsx
+++ b/demo/pages/Calendar/index.axml.tsx
@@ -35,6 +35,7 @@ export default ({
           <AntCalendar
             selectionMode="single"
             defaultValue={demo2.defaultValue}
+            changedScrollIntoView
           />
         </View>
       </CollapseContainer>

--- a/demo/pages/Calendar/index.ts
+++ b/demo/pages/Calendar/index.ts
@@ -54,7 +54,7 @@ Page({
       visible: true,
     },
     demo2: {
-      defaultValue: Date.now(),
+      defaultValue: dayjs().add(1, 'M').toDate().getTime(),
       visible: true,
     },
     demo3: {

--- a/src/Calendar/index.axml.tsx
+++ b/src/Calendar/index.axml.tsx
@@ -13,7 +13,13 @@ import {
 
 export default (
   { className, style }: TSXMLProps<ICalendarProps>,
-  { markItems, elementSize, monthList, headerState }: InternalData
+  {
+    markItems,
+    elementSize,
+    monthList,
+    headerState,
+    scrollIntoViewId,
+  }: InternalData
 ) => (
   <View class={`ant-calendar ${className ? className : ''}`} style={style}>
     <View class="ant-calendar-mark">
@@ -45,6 +51,9 @@ export default (
       data-elementsize={elementSize}
       data-monthlist={monthList}
       onScroll={scroll.handleScroll}
+      scroll-into-view={scrollIntoViewId}
+      scroll-with-animation
+      scroll-animation-duration={300}
       ref="handleRef"
     >
       {monthList.map((currentMonth) => (
@@ -65,6 +74,7 @@ export default (
               <Block>
                 <View
                   class={helper.getClassName(item, index)}
+                  id={`id_${item.time}`}
                   data-time={item}
                   onTap="clickCell"
                 >

--- a/src/Calendar/index.md
+++ b/src/Calendar/index.md
@@ -21,16 +21,18 @@ toc: 'content'
 
 以下为日历组件的属性及描述：
 
-| 属性          | 说明                                            | 类型                                                        | 默认值      |
-| ------------- | ---------------------------------------------- | ----------------------------------------------------------- | ----------- |
-| defaultValue  | 初始值                                          | CalendarValue                                               | 无          |
-| value         | 日历选择的日期，传入后即为受控模式                   | CalendarValue                                               | 无          |
-| selectionMode | 设置选择模式，单选或者连续区间，默认为 `range`       | `single` \| `range`                                         | `range`     |
-| monthRange    | 月份范围，默认为最近 3 个月                       | `[number, number]`                                          | 最近 3 个月 |
-| weekStartsOn  | 星期栏，以周几作为第一天显示。默认为 `Sunday`       | `Sunday` \| `Monday`                                        | `Sunday`    |
-| onChange      | 日期变化回调                                    | (date: CalendarValue) => void                               | 无          |
-| onFormatter   | 用于设置单元格的自定义数据                        | (cell: CellState, currentValue: CalendarValue) => CellState  | 无          |
-| localeText    | 国际化文案                                      | Partial`<LocaleText>`                                       | 无          |
+| 属性                  | 说明                                           | 类型                                                        | 默认值      |
+| --------------------- | ---------------------------------------------- | ----------------------------------------------------------- | ----------- |
+| defaultValue          | 初始值                                         | CalendarValue                                               | 无          |
+| value                 | 日历选择的日期，传入后即为受控模式             | CalendarValue                                               | 无          |
+| selectionMode         | 设置选择模式，单选或者连续区间，默认为 `range` | `single` \| `range`                                         | `range`     |
+| monthRange            | 月份范围，默认为最近 3 个月                    | `[number, number]`                                          | 最近 3 个月 |
+| weekStartsOn          | 星期栏，以周几作为第一天显示。默认为 `Sunday`  | `Sunday` \| `Monday`                                        | `Sunday`    |
+| onChange              | 日期变化回调                                   | (date: CalendarValue) => void                               | 无          |
+| onFormatter           | 用于设置单元格的自定义数据                     | (cell: CellState, currentValue: CalendarValue) => CellState | 无          |
+| localeText            | 国际化文案                                     | Partial`<LocaleText>`                                       | 无          |
+| changedScrollIntoView | 选中值改变后是否滚动视图                       | boolean                                                     | 无          |
+
 ### 类型
 
 **CalendarValue** : 日历的值类型，为数字或数字元组 `number | [number,number]`，表示单选或连续日期区间。单位为毫秒的时间戳。

--- a/src/Calendar/index.ts
+++ b/src/Calendar/index.ts
@@ -188,11 +188,19 @@ const Calendar = (props: ICalendarProps) => {
     }
   });
 
+  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
+  const scrollIntoViewId = `id_${dayjs(Array.isArray(value) ? value[0] : value)
+    .startOf('d')
+    .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
+    .toDate()
+    .getTime()}`;
+
   return {
     elementSize,
     markItems,
     monthList,
     headerState,
+    scrollIntoViewId,
   };
 };
 

--- a/src/Calendar/index.ts
+++ b/src/Calendar/index.ts
@@ -4,6 +4,7 @@ import {
   useEvent,
   useReady,
   useState,
+  useEffect,
 } from 'functional-mini/component';
 import { mountComponent } from '../_util/component';
 import { useComponentEvent } from '../_util/hooks/useComponentEvent';
@@ -74,9 +75,6 @@ const Calendar = (props: ICalendarProps) => {
   function updateValue(newValue: CalendarValue) {
     const isControl = hasValue(props.value);
     triggerEvent('change', newValue);
-    // 滚动到已选的位置
-    props.changedScrollIntoView &&
-      setScrollIntoViewId(getScrollIntoViewId(newValue));
     if (!isControl) {
       setValue(newValue);
     }
@@ -194,11 +192,22 @@ const Calendar = (props: ICalendarProps) => {
       });
   }
 
+  useEffect(() => {
+    // 滚动到已选的位置
+    props.changedScrollIntoView &&
+      setScrollIntoViewId(getScrollIntoViewId(value));
+  }, [value]);
+
   useReady(() => {
     measurement();
-    // 初始化默认值时，滚动到默认值位置
-    props.defaultValue &&
-      setScrollIntoViewId(getScrollIntoViewId(props.defaultValue));
+    // 初始化默认值时，滚动到选中位置
+    const isControl = hasValue(props.value);
+    if (isControl) {
+      setScrollIntoViewId(getScrollIntoViewId(props.value));
+    } else {
+      props.defaultValue &&
+        setScrollIntoViewId(getScrollIntoViewId(props.defaultValue));
+    }
   }, []);
 
   useEvent('measurement', () => {

--- a/src/Calendar/index.ts
+++ b/src/Calendar/index.ts
@@ -37,6 +37,19 @@ function getBoundingClientRect(instance: any, selector: string) {
   });
 }
 
+// 获取滚动视图的元素id
+function getScrollIntoViewId(value) {
+  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
+  return `id_${
+    value &&
+    dayjs(Array.isArray(value) ? value[0] : value)
+      .startOf('d')
+      .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
+      .toDate()
+      .getTime()
+  }`;
+}
+
 const Calendar = (props: ICalendarProps) => {
   const localeText = Object.assign({}, defaultLocaleText, props.localeText);
 
@@ -51,6 +64,8 @@ const Calendar = (props: ICalendarProps) => {
     value: props.value,
   });
 
+  const [scrollIntoViewId, setScrollIntoViewId] = useState<string>('');
+
   const selectionModeFromValue = getSelectionModeFromValue(value);
   const selectionMode =
     props.selectionMode ?? selectionModeFromValue ?? 'range';
@@ -59,6 +74,9 @@ const Calendar = (props: ICalendarProps) => {
   function updateValue(newValue: CalendarValue) {
     const isControl = hasValue(props.value);
     triggerEvent('change', newValue);
+    // 滚动到已选的位置
+    props.changedScrollIntoView &&
+      setScrollIntoViewId(getScrollIntoViewId(newValue));
     if (!isControl) {
       setValue(newValue);
     }
@@ -178,6 +196,9 @@ const Calendar = (props: ICalendarProps) => {
 
   useReady(() => {
     measurement();
+    // 初始化默认值时，滚动到默认值位置
+    props.defaultValue &&
+      setScrollIntoViewId(getScrollIntoViewId(props.defaultValue));
   }, []);
 
   useEvent('measurement', () => {
@@ -187,13 +208,6 @@ const Calendar = (props: ICalendarProps) => {
       measurement();
     }
   });
-
-  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
-  const scrollIntoViewId = `id_${dayjs(Array.isArray(value) ? value[0] : value)
-    .startOf('d')
-    .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
-    .toDate()
-    .getTime()}`;
 
   return {
     elementSize,

--- a/src/Calendar/index.ts
+++ b/src/Calendar/index.ts
@@ -20,6 +20,7 @@ import {
   getMonthListFromRange,
   getSelectionModeFromValue,
   renderCells,
+  getScrollIntoViewId,
 } from './utils';
 
 function getBoundingClientRect(instance: any, selector: string) {
@@ -36,19 +37,6 @@ function getBoundingClientRect(instance: any, selector: string) {
         }
       });
   });
-}
-
-// 获取滚动视图的元素id
-function getScrollIntoViewId(value) {
-  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
-  return `id_${
-    value &&
-    dayjs(Array.isArray(value) ? value[0] : value)
-      .startOf('d')
-      .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
-      .toDate()
-      .getTime()
-  }`;
 }
 
 const Calendar = (props: ICalendarProps) => {

--- a/src/Calendar/props.ts
+++ b/src/Calendar/props.ts
@@ -115,6 +115,10 @@ export interface ICalendarProps extends IBaseProps {
    */
   localeText?: Partial<LocaleText>;
   /**
+   * 选中值改变后滚动视图
+   */
+  changedScrollIntoView?: boolean;
+  /**
    * 日期变化回调
    */
   onChange?: (date: CalendarValue) => void;

--- a/src/Calendar/utils.ts
+++ b/src/Calendar/utils.ts
@@ -161,3 +161,16 @@ export function getSelectionModeFromValue(
   }
   return null;
 }
+
+// 获取滚动视图的元素id
+export function getScrollIntoViewId(value: CalendarValue) {
+  // 已选中时间滚动到可视区域内（微信不支持id为数字开头）
+  return `id_${
+    value &&
+    dayjs(Array.isArray(value) ? value[0] : value)
+      .startOf('d')
+      .subtract(7, 'd') // 需要定位的地方往前推7天，让已选中时间定位到中间位置
+      .toDate()
+      .getTime()
+  }`;
+}

--- a/tests/alipay/Calendar/__tests__/calendar.spec.ts
+++ b/tests/alipay/Calendar/__tests__/calendar.spec.ts
@@ -2,19 +2,27 @@ import dayjs from 'dayjs';
 import { describe, expect, it, vi } from 'vitest';
 import { findDate, getSelectedDay, initCalendar, sleep } from './testUtils';
 import { TestInstance } from 'tests/utils';
+import { getScrollIntoViewId } from 'compiled-alipay/Calendar/utils';
 
 describe('Calendar', () => {
   it('测试默认值', () => {
     const instance = initCalendar({});
 
-    const { className, style, localeText, selectionMode, weekStartsOn } =
-      instance.getConfig().props;
+    const {
+      className,
+      style,
+      localeText,
+      selectionMode,
+      weekStartsOn,
+      changedScrollIntoView,
+    } = instance.getConfig().props;
     expect({
       className,
       style,
       localeText,
       selectionMode,
       weekStartsOn,
+      changedScrollIntoView,
     }).toMatchFileSnapshot('snapshot/alipay_config_props.txt');
 
     const initData = instance.getData();
@@ -289,5 +297,32 @@ describe('Calendar', () => {
     extendFunctions.clickCell('2023-01-02');
     await sleep(100);
     expect(getSelectedDay(instance.getData())).toEqual(['2023-01-02']);
+  });
+
+  it('测试滚动到选中位置', async () => {
+    const defaultValue = dayjs().add(1, 'M').toDate().getTime();
+    const instance = initCalendar({
+      defaultValue,
+      selectionMode: 'single',
+      changedScrollIntoView: true,
+    });
+    expect(instance.getData().scrollIntoViewId).toEqual(
+      getScrollIntoViewId(defaultValue)
+    );
+
+    const extendFunctions = extendInstance(instance);
+    extendFunctions.clickCell(
+      dayjs(defaultValue).add(1, 'd').format('YYYY-MM-DD')
+    );
+    await sleep(300);
+    expect(instance.getData().scrollIntoViewId).toEqual(
+      getScrollIntoViewId(dayjs(defaultValue).add(1, 'd').toDate().getTime())
+    );
+
+    extendFunctions.clickCell('2024-03-28');
+    await sleep(300);
+    expect(instance.getData().scrollIntoViewId).toEqual(
+      getScrollIntoViewId(dayjs('2024-03-28').toDate().getTime())
+    );
   });
 });

--- a/tests/alipay/Calendar/__tests__/snapshot/alipay_config_props.txt
+++ b/tests/alipay/Calendar/__tests__/snapshot/alipay_config_props.txt
@@ -1,4 +1,5 @@
 {
+  "changedScrollIntoView": undefined,
   "className": undefined,
   "localeText": {
     "end": "结束",

--- a/tests/alipay/Calendar/__tests__/utils.spec.ts
+++ b/tests/alipay/Calendar/__tests__/utils.spec.ts
@@ -1,6 +1,10 @@
 import dayjs, { Dayjs } from 'dayjs';
 import { describe, expect, it } from 'vitest';
-import { getDate, getMonthListFromRange } from 'compiled-alipay/Calendar/utils';
+import {
+  getDate,
+  getMonthListFromRange,
+  getScrollIntoViewId,
+} from 'compiled-alipay/Calendar/utils';
 
 describe('Calendar utils', () => {
   it('test dayjsToCalendarDate', () => {
@@ -30,6 +34,15 @@ it('测试 checkDates 生成的日期是否正确', () => {
     expect(checkDates(flag, 'Monday')).toBeTruthy();
     expect(checkDates(flag, 'Sunday')).toBeTruthy();
     flag = flag.add(1, 'month');
+  }
+});
+
+it('测试 getScrollIntoViewId 获取滚动视图的元素id是否正确', () => {
+  let flag = dayjs('2024-03-29 13:40:23').toDate().getTime();
+  for (let i = 0; i < 12 * 100; i++) {
+    expect(getScrollIntoViewId(flag)).toEqual(
+      `id_${dayjs('2024-03-22').toDate().getTime()}`
+    );
   }
 });
 


### PR DESCRIPTION
https://ant-design-mini.antgroup.com/components/calendar  这个 calendar 组件似乎没有滑动到指定日期的 API，这个有计划支持吗？

比如日历渲染的日期是 1.1 - 12.31，日历组件选中的值是 5.1，需要在打开这个日历组件时，就自动滑动到选中的日期上

而不是每次打开这个组件的时候，都需要从头开始滑动