### PR TITLE
fix: [#1149]修复RangePicker和CascaderPicker组件onVisibleChange事件参数未适配微信的问题

### DIFF
--- a/compiled/alipay/src/DatePicker/RangePicker/index.ts
+++ b/compiled/alipay/src/DatePicker/RangePicker/index.ts
@@ -13,7 +13,7 @@ import { useDateState } from './useDateState';
 import { mountComponent } from '../../_util/component';
 import { PickerValue } from '../props';
 import { useComponentEvent } from '../../_util/hooks/useComponentEvent';
-import { resolveEventValues } from '../../_util/platform';
+import { resolveEventValues, resolveEventValue } from '../../_util/platform';
 
 const RangePicker = (props: IDateRangePickerProps) => {
   const [realValue, { isControlled, update }] = useMixState<PickerValue[]>(
@@ -82,7 +82,8 @@ const RangePicker = (props: IDateRangePickerProps) => {
 
   const formattedValueText = onFormat(realValue);
 
-  useEvent('onVisibleChange', (visible) => {
+  useEvent('onVisibleChange', (event) => {
+    const visible = resolveEventValue(event)
     if (visible) {
       const state = init(realValue);
       const currentValue = getValueByDate(

--- a/compiled/alipay/src/Picker/CascaderPicker/index.ts
+++ b/compiled/alipay/src/Picker/CascaderPicker/index.ts
@@ -3,7 +3,7 @@ import { mountComponent } from '../../_util/component';
 import { useComponentEvent } from '../../_util/hooks/useComponentEvent';
 import { useComponentUpdateEffect } from '../../_util/hooks/useLayoutEffect';
 import { useMixState } from '../../_util/hooks/useMixState';
-import { resolveEventValues } from '../../_util/platform';
+import { resolveEventValues, resolveEventValue } from '../../_util/platform';
 import { CascaderFunctionalProps, ICascaderProps } from './props';
 import { defaultFormat, getterColumns, getValidValue } from './utils';
 
@@ -83,7 +83,8 @@ const CascaderPicker = (props: ICascaderProps) => {
     return defaultFormat(realValue, getOptionByValue(realValue, props.options));
   }, [realValue]);
 
-  useEvent('onVisibleChange', (visible) => {
+  useEvent('onVisibleChange', (event) => {
+    const visible = resolveEventValue(event)
     if (visible) {
       const newColumns = getterColumns(realValue, props.options);
       const currentValue = getValidValue(realValue, newColumns);

--- a/compiled/wechat/src/DatePicker/RangePicker/index.js
+++ b/compiled/wechat/src/DatePicker/RangePicker/index.js
@@ -7,7 +7,7 @@ import { useFormatValue, useMinAndMax, useFormatLabel } from './hooks';
 import { useDateState } from './useDateState';
 import { mountComponent } from '../../_util/component';
 import { useComponentEvent } from '../../_util/hooks/useComponentEvent';
-import { resolveEventValues } from '../../_util/platform';
+import { resolveEventValues, resolveEventValue } from '../../_util/platform';
 var RangePicker = function (props) {
     var _a = useMixState(props.defaultValue, {
         value: props.value,
@@ -59,7 +59,8 @@ var RangePicker = function (props) {
         doUpdateColumns({ columns: newColumns, currentValue: currentValue });
     }
     var formattedValueText = onFormat(realValue);
-    useEvent('onVisibleChange', function (visible) {
+    useEvent('onVisibleChange', function (event) {
+        var visible = resolveEventValue(event);
         if (visible) {
             var state = init(realValue);
             var currentValue_1 = getValueByDate(state.pickerType === 'start' ? state.start : state.end, props.precision);

--- a/compiled/wechat/src/Picker/CascaderPicker/index.js
+++ b/compiled/wechat/src/Picker/CascaderPicker/index.js
@@ -3,7 +3,7 @@ import { mountComponent } from '../../_util/component';
 import { useComponentEvent } from '../../_util/hooks/useComponentEvent';
 import { useComponentUpdateEffect } from '../../_util/hooks/useLayoutEffect';
 import { useMixState } from '../../_util/hooks/useMixState';
-import { resolveEventValues } from '../../_util/platform';
+import { resolveEventValues, resolveEventValue } from '../../_util/platform';
 import { CascaderFunctionalProps } from './props';
 import { defaultFormat, getterColumns, getValidValue } from './utils';
 var CascaderPicker = function (props) {
@@ -71,7 +71,8 @@ var CascaderPicker = function (props) {
         }
         return defaultFormat(realValue, getOptionByValue(realValue, props.options));
     }, [realValue]);
-    useEvent('onVisibleChange', function (visible) {
+    useEvent('onVisibleChange', function (event) {
+        var visible = resolveEventValue(event);
         if (visible) {
             var newColumns = getterColumns(realValue, props.options);
             var currentValue = getValidValue(realValue, newColumns);

--- a/src/DatePicker/RangePicker/index.ts
+++ b/src/DatePicker/RangePicker/index.ts
@@ -13,7 +13,7 @@ import { useDateState } from './useDateState';
 import { mountComponent } from '../../_util/component';
 import { PickerValue } from '../props';
 import { useComponentEvent } from '../../_util/hooks/useComponentEvent';
-import { resolveEventValues } from '../../_util/platform';
+import { resolveEventValues, resolveEventValue } from '../../_util/platform';
 
 const RangePicker = (props: IDateRangePickerProps) => {
   const [realValue, { isControlled, update }] = useMixState<PickerValue[]>(
@@ -82,7 +82,8 @@ const RangePicker = (props: IDateRangePickerProps) => {
 
   const formattedValueText = onFormat(realValue);
 
-  useEvent('onVisibleChange', (visible) => {
+  useEvent('onVisibleChange', (event) => {
+    const visible = resolveEventValue(event)
     if (visible) {
       const state = init(realValue);
       const currentValue = getValueByDate(

--- a/src/Picker/CascaderPicker/index.ts
+++ b/src/Picker/CascaderPicker/index.ts
@@ -3,7 +3,7 @@ import { mountComponent } from '../../_util/component';
 import { useComponentEvent } from '../../_util/hooks/useComponentEvent';
 import { useComponentUpdateEffect } from '../../_util/hooks/useLayoutEffect';
 import { useMixState } from '../../_util/hooks/useMixState';
-import { resolveEventValues } from '../../_util/platform';
+import { resolveEventValues, resolveEventValue } from '../../_util/platform';
 import { CascaderFunctionalProps, ICascaderProps } from './props';
 import { defaultFormat, getterColumns, getValidValue } from './utils';
 
@@ -83,7 +83,8 @@ const CascaderPicker = (props: ICascaderProps) => {
     return defaultFormat(realValue, getOptionByValue(realValue, props.options));
   }, [realValue]);
 
-  useEvent('onVisibleChange', (visible) => {
+  useEvent('onVisibleChange', (event) => {
+    const visible = resolveEventValue(event)
     if (visible) {
       const newColumns = getterColumns(realValue, props.options);
       const currentValue = getValidValue(realValue, newColumns);


### PR DESCRIPTION
修复RangePicker和CascaderPicker组件与DatePicker相同的问题，https://github.com/ant-design/ant-design-mini/issues/1149