### PR TITLE
Update index.less

### DIFF
--- a/src/ImageUpload/index.less
+++ b/src/ImageUpload/index.less
@@ -9,6 +9,10 @@
 
   &-show {
     position: relative;
+
+    view {
+      z-index: 1;
+    }
   }
 
   &-image {


### PR DESCRIPTION
修复 微信小程序 skyline 模式下 ant-image-upload-show 下 ant-image-upload-close  被 ant-image-upload-image 挡住的问题
<img width="962" alt="f1ed0d4a8d7772edc3c9e4b2cfbf6a9" src="https://github.com/ant-design/ant-design-mini/assets/85245446/f769f909-f05b-4589-a75a-7a6607cbc66f">
