### PR TITLE
Update the link to the correct migration documentation

### DIFF
--- a/docs/guide/faq.en.md
+++ b/docs/guide/faq.en.md
@@ -7,7 +7,7 @@ toc: true
 
 ### 3. Can x be used with 2.x, 1.x, 0.x
 
-Because there is no migration cost to upgrade from 2.x, 1.x to 3.x, you can do it directly from 2.x, 1.x. upgrade to 3.x, under reference[Upgrade Guide](http://localhost:8000/guide/migration)。
+Because there is no migration cost to upgrade from 2.x, 1.x to 3.x, you can do it directly from 2.x, 1.x. upgrade to 3.x, under reference[Upgrade Guide](https://mini.ant.design/guide/migration)。
 
 For 0.x, you can use the npm alias to install.
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -7,7 +7,7 @@ toc: true
 
 ### 3.x 能否和 2.x, 1.x, 0.x 一起使用
 
-因为 2.x, 1.x 升级到 3.x 没有迁移成本，所以你可以直接从 2.x, 1.x 升级到 3.x，参考下[升级指南](http://localhost:8000/guide/migration)。
+因为 2.x, 1.x 升级到 3.x 没有迁移成本，所以你可以直接从 2.x, 1.x 升级到 3.x，参考下[升级指南](https://mini.ant.design/guide/migration)。
 
 对于 0.x, 你可以使用 npm 别名来安装。
 


### PR DESCRIPTION
迁移文档的链接指的是本地主机而不是文档域。


The link to the migration document refers to the localhost instead of the documentation domain.