### PR TITLE
Update popup index.ts

### DIFF
--- a/src/Popup/index.ts
+++ b/src/Popup/index.ts
@@ -83,7 +83,7 @@ Component(
     /// #if WECHAT
     observers: {
       'visible': function (nextProps) {
-        const { visible, duration, animation } = nextProps;
+        const { visible, duration, animation } = this.data;
         const enableAnimation = animation && duration > 0;
         if (enableAnimation && !visible && !this.data.closing) {
           this.setData({ closing: true });


### PR DESCRIPTION
用户在页面中修改 visible 的状态，关闭弹窗时，动效不起作用。
原因是： visible 是 Boolean值，但是代码中，observers 中的visible却是按照对象处理的。