### PR TITLE
Feat popup close slot

### DIFF
--- a/demo/pages/Popup/index.axml
+++ b/demo/pages/Popup/index.axml
@@ -1,4 +1,3 @@
-<view class="navigation-bar"/>
 
 <ant-popup
   visible="{{ basicVisible }}"
@@ -119,6 +118,27 @@
     proident elit.
   </scroll-view>
 </ant-popup>
+<ant-popup
+  visible="{{ slotVisible }}"
+  position="bottom"
+  showClose="{{ true }}"
+  showBack="{{ true }}"
+  animation="{{ animation }}"
+  onClickBack="onClickBack"
+  onClose="handlePopupClose">
+    <view slot="header-close" class="header-close">
+      x
+    </view>
+    <view slot="header-back" class="header-back">
+      <
+    </view>
+    <view slot="header-title" class="header-title">
+      标题
+    </view>
+    <view class="customize-content">
+      从屏幕滑出或弹出一块自定义内容区，用于展示弹窗、信息提示、选择输入、切换等内容。
+    </view>
+</ant-popup>
 <container
   title="弹出位置"
   className="list">
@@ -145,6 +165,7 @@
   <ant-button onTap="handleShowCustomize">自定义弹框内容 并支持背景图</ant-button>
   <ant-button onTap="handleShowTopImage">顶部图片</ant-button>
   <ant-button onTap="handleShowScroll">超长内容滚动</ant-button>
+  <ant-button onTap="handleShowSlot">插槽定制Header</ant-button>
 </container>
 <list>
   <list-item>

--- a/demo/pages/Popup/index.axml
+++ b/demo/pages/Popup/index.axml
@@ -118,6 +118,7 @@
     proident elit.
   </scroll-view>
 </ant-popup>
+<!-- #if ALIPAY -->
 <ant-popup
   visible="{{ slotVisible }}"
   position="bottom"
@@ -130,7 +131,7 @@
       x
     </view>
     <view slot="header-back" class="header-back">
-      <
+      返回
     </view>
     <view slot="header-title" class="header-title">
       标题
@@ -139,6 +140,7 @@
       从屏幕滑出或弹出一块自定义内容区，用于展示弹窗、信息提示、选择输入、切换等内容。
     </view>
 </ant-popup>
+<!-- #endif -->
 <container
   title="弹出位置"
   className="list">
@@ -165,7 +167,9 @@
   <ant-button onTap="handleShowCustomize">自定义弹框内容 并支持背景图</ant-button>
   <ant-button onTap="handleShowTopImage">顶部图片</ant-button>
   <ant-button onTap="handleShowScroll">超长内容滚动</ant-button>
+  <!-- #if ALIPAY -->
   <ant-button onTap="handleShowSlot">插槽定制Header</ant-button>
+  <!-- #endif -->
 </container>
 <list>
   <list-item>

--- a/demo/pages/Popup/index.json5
+++ b/demo/pages/Popup/index.json5
@@ -5,8 +5,6 @@
 
   /// #if ALIPAY
   "defaultTitle": "Popup",
-  "transparentTitle": "auto",
-  "titlePenetrate": "YES",
   /// #endif
 
   "usingComponents": {

--- a/demo/pages/Popup/index.less
+++ b/demo/pages/Popup/index.less
@@ -32,3 +32,13 @@
     padding-top: 30rpx;
   }
 }
+
+.header-back {
+  font-size: 48rpx;
+  color: #999999;
+}
+
+.header-close {
+  font-size: 48rpx;
+  color: #999999;
+}

--- a/demo/pages/Popup/index.less
+++ b/demo/pages/Popup/index.less
@@ -34,7 +34,7 @@
 }
 
 .header-back {
-  font-size: 48rpx;
+  font-size: 24rpx;
   color: #999999;
 }
 

--- a/demo/pages/Popup/index.ts
+++ b/demo/pages/Popup/index.ts
@@ -16,6 +16,7 @@ Page({
       scrollVisible: false,
       customizeVisible: false,
       topImageVisible: false,
+      slotVisible: false,
     });
   },
   handleShowBasic(e) {
@@ -27,6 +28,9 @@ Page({
   },
   handleShowScroll() {
     this.setData({ scrollVisible: true });
+  },
+  handleShowSlot() {
+    this.setData({ slotVisible: true });
   },
   handleChangeAnimation(checked) {
     /// #if ALIPAY

--- a/src/Popup/index.axml
+++ b/src/Popup/index.axml
@@ -19,33 +19,49 @@
     style="{{ utils.getContentStyle(position, animation, duration, width, height) }}"
     onAnimationEnd="onAnimationEnd">
     <view a:if="{{ backgroundImage }}" class="ant-popup-content-bg" style="background-image: url({{backgroundImage}});"/>
+    <!-- #if ALIPAY -->
     <slot name="header">
+    <!-- #endif -->
       <view a:if="{{ title || showClose || showBack }}" class="ant-popup-content-header">
         <view
-          className="ant-popup-content-header-icon ant-popup-content-header-icon-back"
+          class="ant-popup-content-header-icon ant-popup-content-header-icon-back"
           a:if="{{ showBack }}"
           onTap="onClickBack">
+          <!-- #if ALIPAY -->
           <slot name="header-back">
+          <!-- #endif -->
             <ant-icon
               type="LeftOutline" />
+          <!-- #if ALIPAY -->
           </slot>
+          <!-- #endif -->
         </view>
         <view class="ant-popup-content-header-title">
+          <!-- #if ALIPAY -->
           <slot name="header-title">
+          <!-- #endif -->
             {{ title }}
+          <!-- #if ALIPAY -->
           </slot>
+          <!-- #endif -->
         </view>
         <view
-          className="ant-popup-content-header-icon ant-popup-content-header-icon-close"
+          class="ant-popup-content-header-icon ant-popup-content-header-icon-close"
           a:if="{{ showClose }}"
           onTap="onClickCloseIcon">
+            <!-- #if ALIPAY -->
             <slot name="header-close">
+            <!-- #endif -->
               <ant-icon
                 type="CloseOutline" />
+            <!-- #if ALIPAY -->
             </slot>
+            <!-- #endif -->
           </view>
       </view>
+    <!-- #if ALIPAY -->
     </slot>
+    <!-- #endif -->
     <slot />
     <slot
       a:if="{{ isOldVersion }}"

--- a/src/Popup/index.axml
+++ b/src/Popup/index.axml
@@ -19,21 +19,33 @@
     style="{{ utils.getContentStyle(position, animation, duration, width, height) }}"
     onAnimationEnd="onAnimationEnd">
     <view a:if="{{ backgroundImage }}" class="ant-popup-content-bg" style="background-image: url({{backgroundImage}});"/>
-    <view a:if="{{ title || showClose || showBack }}" class="ant-popup-content-header">
-      <ant-icon
-        className="ant-popup-content-header-icon ant-popup-content-header-icon-back"
-        type="LeftOutline"
-        a:if="{{ showBack }}"
-        onTap="onClickBack" />
-      <view class="ant-popup-content-header-title">
-        {{ title }}
+    <slot name="header">
+      <view a:if="{{ title || showClose || showBack }}" class="ant-popup-content-header">
+        <view
+          className="ant-popup-content-header-icon ant-popup-content-header-icon-back"
+          a:if="{{ showBack }}"
+          onTap="onClickBack">
+          <slot name="header-back">
+            <ant-icon
+              type="LeftOutline" />
+          </slot>
+        </view>
+        <view class="ant-popup-content-header-title">
+          <slot name="header-title">
+            {{ title }}
+          </slot>
+        </view>
+        <view
+          className="ant-popup-content-header-icon ant-popup-content-header-icon-close"
+          a:if="{{ showClose }}"
+          onTap="onClickCloseIcon">
+            <slot name="header-close">
+              <ant-icon
+                type="CloseOutline" />
+            </slot>
+          </view>
       </view>
-      <ant-icon
-        className="ant-popup-content-header-icon ant-popup-content-header-icon-close"
-        type="CloseOutline"
-        a:if="{{ showClose }}"
-        onTap="onClickCloseIcon" />
-    </view>
+    </slot>
     <slot />
     <slot
       a:if="{{ isOldVersion }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 针对支付宝平台新增 Popup 组件的自定义 Header 插槽功能，支持自定义关闭按钮、返回按钮和标题内容。
  - 新增“插槽定制Header”按钮，点击可展示带自定义 Header 的弹窗示例。

- **样式**
  - 新增自定义 Header 返回按钮和关闭按钮的样式。

- **其他**
  - 优化 Popup 组件在支付宝平台的插槽结构，提升头部内容的可定制性。
  - 移除部分页面配置项，保持标题显示一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->