### PR TITLE
fIx: 修复日历组件sticky标题位置错乱问题

### DIFF
--- a/demo/pages/Calendar/index.axml
+++ b/demo/pages/Calendar/index.axml
@@ -150,7 +150,9 @@
     width="{{250}}"
     height="{{600}}"
     onClose="onPopupClose">
-    <ant-calendar></ant-calendar>
+    <ant-calendar
+      monthRange="{{demo10.monthRange}}"
+      ></ant-calendar>
   </ant-popup>
 
 </view>

--- a/demo/pages/Calendar/index.ts
+++ b/demo/pages/Calendar/index.ts
@@ -102,6 +102,10 @@ Page({
     },
     demo10: {
       visible: false,
+      monthRange: [
+        dayjs().subtract(1, 'year').valueOf(),
+        dayjs().add(1, 'year').valueOf(),
+      ],
     },
   },
   demo3NextMonth() {

--- a/src/Calendar/index.less
+++ b/src/Calendar/index.less
@@ -76,10 +76,10 @@
   }
 
   &-cell {
-    box-sizing: border-box;
+    box-sizing: content-box;
     width: calc((100% - 6 * @calendar-cell-space-size) / 7);
     height: @calendar-cell-height;
-    margin-bottom: @calendar-cell-bottom-margin;
+    padding-bottom: @calendar-cell-bottom-margin;
     position: relative;
 
     &-container {

--- a/src/Calendar/index.ts
+++ b/src/Calendar/index.ts
@@ -82,9 +82,9 @@ ComponentWithSignalStoreImpl({
     },
     measurement() {
       const { elementSize } = this.data;
-      // 组件如果内嵌在 slot 里, 一定会被渲染出来, 但是此时 cellHight 为 0
+      // 组件如果内嵌在 slot 里, 一定会被渲染出来, 但是此时 cellHeight 为 0
       // 此时需要重新计算
-      if (!elementSize || elementSize.cellHight === 0) {
+      if (!elementSize || elementSize.cellHeight === 0) {
         this.measurementFn();
       }
     },
@@ -92,24 +92,27 @@ ComponentWithSignalStoreImpl({
       Promise.all([
         this.getBoundingClientRect('.ant-calendar-body-container'),
         this.getBoundingClientRect('.ant-calendar-cells'),
+        this.getBoundingClientRect('.ant-calendar-cell'),
         this.getBoundingClientRect('.ant-calendar-title-container'),
       ])
-        .then(([bodyContainer, cellContainer, Title]) => {
-          // 滚动的时候 top 和 bottom 等尺寸会变
-          // 所以只能依赖 height 来计算
-          const paddingHeight =
-            bodyContainer.height - cellContainer.height - Title.height;
-          const monthTitleHeight = Title.height + paddingHeight;
-          const cellHight =
-            cellContainer.height / (this.data.monthList[0].cells.length / 7);
-          this.setData({
-            elementSize: {
-              monthTitleHeight,
-              cellHight,
-              paddingHeight,
-            },
-          });
-        })
+        .then(
+          ([bodyContainer, cellsContainer, cellContainer, titleContainer]) => {
+            // 滚动的时候 top 和 bottom 等尺寸会变
+            // 所以只能依赖 height 来计算
+            const paddingHeight =
+              bodyContainer.height -
+              cellsContainer.height -
+              titleContainer.height;
+            const monthTitleHeight = titleContainer.height + paddingHeight;
+            this.setData({
+              elementSize: {
+                monthTitleHeight,
+                cellHeight: cellContainer.height,
+                paddingHeight,
+              },
+            });
+          }
+        )
         .catch(() => {
           this.setData({ elementSize: null });
         });

--- a/src/Calendar/scroll.sjs.ts
+++ b/src/Calendar/scroll.sjs.ts
@@ -5,8 +5,8 @@ function handleScroll(event, ownerComponent) {
   if (!elementSize) {
     return;
   }
-  // 组件如果内嵌在 slot 里, 一定会被渲染出来, 但是此时 cellHight 为 0
-  if (elementSize.cellHight === 0) {
+  // 组件如果内嵌在 slot 里, 一定会被渲染出来, 但是此时 cellHeight 为 0
+  if (elementSize.cellHeight === 0) {
     ownerComponent.callMethod('measurement');
     return;
   }
@@ -19,7 +19,7 @@ function handleScroll(event, ownerComponent) {
   }
   const monthHeight = elementSize.monthTitleHeight;
   const paddingHeight = elementSize.paddingHeight;
-  const cellHeight = elementSize.cellHight;
+  const cellHeight = elementSize.cellHeight;
   const heightList = monthList.map((p) => {
     return monthHeight + (cellHeight * p.cells.length) / 7;
   });

--- a/src/Grid/index.less
+++ b/src/Grid/index.less
@@ -3,6 +3,7 @@
 .@{gridPrefix} {
   padding: 24 * @rpx;
   box-sizing: border-box;
+  row-gap: 24 * @rpx;
   &-columns-3 {
     padding: 24 * @rpx 0;
   }
@@ -51,7 +52,7 @@
       justify-content: flex-start;
       align-items: center;
       flex-direction: row;
-      .@{gridPrefix}-item-info { 
+      .@{gridPrefix}-item-info {
         padding-left: 16 * @rpx;
         display: flex;
         justify-content: center;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 日历弹窗内的日历组件现在支持自定义月份范围，展示从当前日期前一年到后一年的区间。

- **样式**
  - 优化了日历单元格的布局和底部间距，可能影响日历的显示效果。
  - 网格布局新增了行间距，提升了内容的垂直分隔效果。

- **修复**
  - 修正了部分注释和变量名中的拼写错误，提高了代码一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->