### PR TITLE
feat(table): [#1480] 新增表格单元格render方法

### DIFF
--- a/src/Table/index.axml
+++ b/src/Table/index.axml
@@ -58,7 +58,7 @@
                     class="{{val.ellipsisRow ? 'ant-table-list-item-ellipsis' : ''}}"
                     style="{{val.ellipsisRow ? `-webkit-line-clamp:${val.ellipsisRow}`: ''}}"
                   >
-                    {{val.value}}
+                    {{val.cellValue}}
                   </view>
                   <!-- #if ALIPAY || ALIPAYNATIVE -->
                 </slot>

--- a/src/Table/index.md
+++ b/src/Table/index.md
@@ -166,15 +166,16 @@ Page({
 
 ### Column
 
-| 属性           | 说明                         | 类型    | 默认值 |
-| -------------- | ---------------------------- | ------- | ------ |
-| title          | 列标题                       | string  | -      |
-| dataIndex      | 列取值字段                   | string  | -      |
-| key            | 列唯一标识                   | string  | -      |
-| width          | 列宽度                       | number  | -      |
-| fixed          | 是否固定列                   | boolean | -      |
-| textAlignRight | 列文本是否右对齐             | boolean | -      |
-| ellipsisRow    | 单元格最大展示行数，超出省略 | number  | -      |
+| 属性           | 说明                                                         | 类型                              | 默认值 |
+| -------------- | ------------------------------------------------------------ | --------------------------------- | ------ |
+| title          | 列标题                                                       | string                            | -      |
+| dataIndex      | 列取值字段                                                   | string                            | -      |
+| key            | 列唯一标识                                                   | string                            | -      |
+| width          | 列宽度                                                       | number                            | -      |
+| fixed          | 是否固定列                                                   | boolean                           | -      |
+| textAlignRight | 列文本是否右对齐                                             | boolean                           | -      |
+| ellipsisRow    | 单元格最大展示行数，超出省略                                 | number                            | -      |
+| render         | 生成复杂数据的渲染函数，参数分别为当前单元格的值，当前行数据，行索引 | function(value, record, index) {} | -      |
 
 
 ## 插槽

--- a/src/Table/index.ts
+++ b/src/Table/index.ts
@@ -73,6 +73,7 @@ Component({
             index: idx,
             dataIndex: val.dataIndex,
             value: v[val.dataIndex],
+            cellValue: val.render ? val.render(v[val.dataIndex], v, i) : v[val.dataIndex],
             textAlignRight: v.textAlignRight || val.textAlignRight,
             rowsData: v,
             widthPx: rpx2px(val.width || defaultWidth, windowWidth),


### PR DESCRIPTION
表格通过column-render方法自定义配置渲染单元格显示内容

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 表格组件的列配置新增 `render` 属性，可用于自定义单元格内容的渲染。
- **文档**
  - 更新了表格组件文档，详细说明并举例了 `render` 属性的用法，优化了列属性表格的排版与可读性。
- **样式**
  - 优化表格行内容渲染，支持通过 `render` 属性展示自定义内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->