### PR TITLE
fix: 修复 CountDown 的微信兼容问题

### DIFF
--- a/src/Countdown/index.ts
+++ b/src/Countdown/index.ts
@@ -1,4 +1,5 @@
-import { duration } from '../_util/dayjs/duration';
+import duration from '../_util/dayjs/duration';
+import dayjs from 'dayjs';
 import {
   Component,
   getValueFromProps,
@@ -6,6 +7,8 @@ import {
   triggerEventOnly,
 } from '../_util/simply';
 import { CountdownDefaultProps } from './props';
+
+dayjs.extend(duration);
 
 Component({
   props: CountdownDefaultProps,
@@ -60,7 +63,7 @@ Component({
           });
         }
 
-        const durationTime = duration(remainTime);
+        const durationTime = dayjs.duration(remainTime);
 
         const day = Math.floor(durationTime.asDays()).toString();
 

--- a/src/Countdown/index.ts
+++ b/src/Countdown/index.ts
@@ -1,5 +1,4 @@
-import dayjs from 'dayjs';
-import duration from 'dayjs/plugin/duration';
+import { duration } from '../_util/dayjs/duration';
 import {
   Component,
   getValueFromProps,
@@ -7,8 +6,6 @@ import {
   triggerEventOnly,
 } from '../_util/simply';
 import { CountdownDefaultProps } from './props';
-
-dayjs.extend(duration);
 
 Component({
   props: CountdownDefaultProps,
@@ -63,7 +60,7 @@ Component({
           });
         }
 
-        const durationTime = dayjs.duration(remainTime);
+        const durationTime = duration(remainTime);
 
         const day = Math.floor(durationTime.asDays()).toString();
 

--- a/src/_util/dayjs/constant.ts
+++ b/src/_util/dayjs/constant.ts
@@ -1,0 +1,35 @@
+/**
+ * see: https://github.com/iamkun/dayjs/blob/dev/src/constant.js
+ */
+export const SECONDS_A_MINUTE = 60;
+export const SECONDS_A_HOUR = SECONDS_A_MINUTE * 60;
+export const SECONDS_A_DAY = SECONDS_A_HOUR * 24;
+export const SECONDS_A_WEEK = SECONDS_A_DAY * 7;
+
+export const MILLISECONDS_A_SECOND = 1e3;
+export const MILLISECONDS_A_MINUTE = SECONDS_A_MINUTE * MILLISECONDS_A_SECOND;
+export const MILLISECONDS_A_HOUR = SECONDS_A_HOUR * MILLISECONDS_A_SECOND;
+export const MILLISECONDS_A_DAY = SECONDS_A_DAY * MILLISECONDS_A_SECOND;
+export const MILLISECONDS_A_WEEK = SECONDS_A_WEEK * MILLISECONDS_A_SECOND;
+
+// English locales
+export const MS = 'millisecond';
+export const S = 'second';
+export const MIN = 'minute';
+export const H = 'hour';
+export const D = 'day';
+export const W = 'week';
+export const M = 'month';
+export const Q = 'quarter';
+export const Y = 'year';
+export const DATE = 'date';
+
+export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ';
+
+export const INVALID_DATE_STRING = 'Invalid Date';
+
+// regex
+export const REGEX_PARSE =
+  /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[Tt\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/;
+export const REGEX_FORMAT =
+  /\[([^\]]+)]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g;

--- a/src/_util/dayjs/duration.ts
+++ b/src/_util/dayjs/duration.ts
@@ -1,0 +1,68 @@
+/**
+ * Duration utility for time calculations
+ *
+ * see: https://github.com/iamkun/dayjs/blob/dev/src/plugin/duration/index.js
+ */
+
+export interface DurationObject {
+  /**
+   * Get as days (total number of days in duration)
+   */
+  asDays(): number;
+
+  /**
+   * Get as hours (total number of hours in duration)
+   */
+  asHours(): number;
+
+  /**
+   * Format duration using template
+   * @param template 格式字符串，支持 HH, mm, ss
+   */
+  format(template: string): string;
+}
+
+/**
+ * Create a Duration object
+ * @param input 毫秒数
+ * @returns Duration对象
+ */
+export function duration(input: number): DurationObject {
+  const $ms = Math.abs(input);
+
+  // 按照 dayjs 标准计算时间单位
+  const $s = Math.floor($ms / 1000);
+  const $m = Math.floor($s / 60);
+  const $h = Math.floor($m / 60);
+  const $d = Math.floor($h / 24);
+
+  return {
+    asDays(): number {
+      return $d;
+    },
+
+    asHours(): number {
+      return $h;
+    },
+
+    format(template: string): string {
+      // 计算显示单位 (取余数)
+      const hours = $h % 24;
+      const minutes = $m % 60;
+      const seconds = $s % 60;
+
+      return template.replace(/HH|mm|ss/g, (match) => {
+        switch (match) {
+          case 'HH':
+            return hours.toString().padStart(2, '0');
+          case 'mm':
+            return minutes.toString().padStart(2, '0');
+          case 'ss':
+            return seconds.toString().padStart(2, '0');
+          default:
+            return match;
+        }
+      });
+    },
+  };
+}


### PR DESCRIPTION
CountDown 微信端报错导致白屏，微信侧 `node_modules`无法通过 `dayjs/plugin/duration` 的路径引入依赖，需要替换为本地实现


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增本地时间间隔工具，支持毫秒输入并自定义格式化输出天、小时、分钟和秒。
  * 新增时间单位常量及格式化相关正则表达式，提升时间计算和格式化的准确性。

* **重构**
  * 倒计时组件切换为使用本地时间间隔工具，提升了时间处理的灵活性和可维护性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->